### PR TITLE
004 | Automatically register new path aliases in Vite confi

### DIFF
--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -26,7 +26,8 @@
         "prettier": "^3.7.4",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.52.0",
-        "vite": "^6.3.1"
+        "vite": "^6.3.1",
+        "vite-tsconfig-paths": "^6.0.4"
       },
       "engines": {
         "node": "22.x"
@@ -1893,6 +1894,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2527,6 +2535,27 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2656,6 +2685,27 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.0.4.tgz",
+      "integrity": "sha512-iIsEJ+ek5KqRTK17pmxtgIxXtqr3qDdE6OxrP9mVeGhVDNXRJTKN/l9oMbujTQNzMLe6XZ8qmpztfbkPu2TiFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3",
+        "vite": "*"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
           "optional": true
         }
       }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,7 +37,8 @@
     "prettier": "^3.7.4",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.52.0",
-    "vite": "^6.3.1"
+    "vite": "^6.3.1",
+    "vite-tsconfig-paths": "^6.0.4"
   },
   "dependencies": {
     "i18next": "^25.7.4",

--- a/packages/client/vite/config.dev.mjs
+++ b/packages/client/vite/config.dev.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
   base: './',

--- a/packages/client/vite/config.dev.mjs
+++ b/packages/client/vite/config.dev.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths'
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   base: './',

--- a/packages/client/vite/config.dev.mjs
+++ b/packages/client/vite/config.dev.mjs
@@ -14,4 +14,5 @@ export default defineConfig({
   server: {
     port: 8080,
   },
+  plugins: [tsconfigPaths()],
 });

--- a/packages/client/vite/config.prod.mjs
+++ b/packages/client/vite/config.prod.mjs
@@ -41,5 +41,5 @@ export default defineConfig({
   server: {
     port: 8080,
   },
-  plugins: [phasermsg()],
+  plugins: [phasermsg(), tsconfigPaths()],
 });

--- a/packages/client/vite/config.prod.mjs
+++ b/packages/client/vite/config.prod.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths'
 
 const phasermsg = () => {
   return {

--- a/packages/client/vite/config.prod.mjs
+++ b/packages/client/vite/config.prod.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths'
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 const phasermsg = () => {
   return {


### PR DESCRIPTION
## Information

#### Describe What Was Done

```
 Plugin: vite:import-analysis
  File: /home/pedro/workspaces/projects/gamedev/phaser/2d-game/slash-out/packages/client/src/game/scenes/game/match/MatchScene.ts:1:45
  1  |  import { defaultKeymapP1 } from "@/ecs/components";
                                         ^
```


TS was throwing the above error because the path aliases were not being recognized by Vite. 

To solve this, the library `vite-tsconfig-paths`  was added to the project so it can automatically register in Vite configs all the path aliases in `tsconfig.json`.

---

#### Detailed Summary (AI Generated)


<details>
	<summary>
🤖| Summary	</summary>
<br />

This pull request adds support for TypeScript path alias resolution in the Vite development and production builds by introducing the `vite-tsconfig-paths` plugin. This improves the developer experience by allowing the use of path aliases defined in `tsconfig.json` throughout the project, making imports cleaner and refactoring easier.

**Build configuration improvements:**

* Added `vite-tsconfig-paths` to the dev dependencies in `package.json` and `package-lock.json`, along with its required dependencies (`globrex`, `tsconfck`). [[1]](diffhunk://#diff-26d3d28d31824ef26252df77cca08d24faea8451cb8fd3ffee2000f9e496daa0L40-R41) [[2]](diffhunk://#diff-cbd47b35e3f05b90928c18d9731e0076d719a674f9b6782ed59b4d9eba240bbdL29-R30) [[3]](diffhunk://#diff-cbd47b35e3f05b90928c18d9731e0076d719a674f9b6782ed59b4d9eba240bbdR1897-R1903) [[4]](diffhunk://#diff-cbd47b35e3f05b90928c18d9731e0076d719a674f9b6782ed59b4d9eba240bbdR2538-R2558) [[5]](diffhunk://#diff-cbd47b35e3f05b90928c18d9731e0076d719a674f9b6782ed59b4d9eba240bbdR2692-R2712)
* Updated both development (`config.dev.mjs`) and production (`config.prod.mjs`) Vite configs to import and register the `vite-tsconfig-paths` plugin, ensuring path aliases are resolved in all build environments. [[1]](diffhunk://#diff-a38ed0e97a9feadf56db0376c4e4296a60d818049869bdccd0780ecba0d6f825R2) [[2]](diffhunk://#diff-a38ed0e97a9feadf56db0376c4e4296a60d818049869bdccd0780ecba0d6f825R18) [[3]](diffhunk://#diff-5233df90dbcedf47a6066477bd39d647d3eacb894ac230df05da1eec80cdf898R2) [[4]](diffhunk://#diff-5233df90dbcedf47a6066477bd39d647d3eacb894ac230df05da1eec80cdf898L44-R45)
	
</details>

---

#### Rollback Plan

Revert from the branch.
