### PR TITLE
014 | Configure collision into map builder

### DIFF
--- a/packages/client/src/game/maps/builder/MapBuilder.ts
+++ b/packages/client/src/game/maps/builder/MapBuilder.ts
@@ -11,8 +11,8 @@ import {
 class MapBuilder {
   private map: Phaser.Tilemaps.Tilemap;
   private customProps: MapCustomProperties;
-  private tilesets: Phaser.Tilemaps.Tileset[];
-  private ground: Phaser.Tilemaps.TilemapLayer[];
+  private tilesets: Phaser.Tilemaps.Tileset[] = [];
+  private ground: Phaser.Tilemaps.TilemapLayer[] = [];
 
   private mapName: string;
   private scene: Phaser.Scene;

--- a/packages/client/src/game/maps/builder/MapBuilder.ts
+++ b/packages/client/src/game/maps/builder/MapBuilder.ts
@@ -96,7 +96,7 @@ class MapBuilder {
     const platforms = this.ground.filter(ground => ground.layer.name.includes('platform'));
 
     if (!platforms?.length) {
-      console.warn(`No platforms layer were found to configure ${this.mapName} map collision.`);
+      console.warn(`No platform layers were found to configure ${this.mapName} map collision.`);
       return;
     }
 

--- a/packages/client/src/game/maps/builder/MapBuilder.ts
+++ b/packages/client/src/game/maps/builder/MapBuilder.ts
@@ -12,6 +12,7 @@ class MapBuilder {
   private map: Phaser.Tilemaps.Tilemap;
   private customProps: MapCustomProperties;
   private tilesets: Phaser.Tilemaps.Tileset[];
+  private ground: Phaser.Tilemaps.TilemapLayer[];
 
   private mapName: string;
   private scene: Phaser.Scene;
@@ -32,6 +33,7 @@ class MapBuilder {
   build() {
     this.createMap();
     this.createWorldLayers();
+    this.createCollision();
 
     this.customProps = this.getCustomProperties();
 
@@ -83,8 +85,22 @@ class MapBuilder {
 
   private createWorldLayers() {
     this.createMapLayer({ layerGroup: 'background', tilesets: this.tilesets });
-    this.createMapLayer({ layerGroup: 'ground', tilesets: this.tilesets });
+    this.ground = this.createMapLayer({ layerGroup: 'ground', tilesets: this.tilesets });
     this.createMapLayer({ layerGroup: 'foreground', tilesets: this.tilesets });
+  }
+
+  private createCollision() {
+    const platforms = this.ground.filter(ground => ground.layer.name.includes('platform'));
+
+    if (!platforms?.length) {
+      console.warn(`No platforms layer were found to configure ${this.mapName} map collision.`);
+      return;
+    }
+
+    platforms.forEach(platform => {
+      platform.setCollisionByProperty({ collider: true });
+      this.scene.matter.world.convertTilemapLayer(platform);
+    });
   }
 
   private setLayerDepth({ layerGroup, layer }: SetLayerDepthProp) {


### PR DESCRIPTION
## Information

#### Describe What Was Done

- Added collision detection for all platform entities loaded in the `MapBuilder`.

---



#### Detailed Summary (AI Generated)


<details>
	<summary>
🤖| Summary	</summary>
<br />

This pull request enhances the map-building process by adding collision detection for platform layers in the map. The main changes involve tracking the ground layers, initializing collision properties for platform tiles, and ensuring that collision setup is integrated into the map build process.

**Collision detection improvements:**
* Added a `ground` property to the `MapBuilder` class to store references to ground layers for later use in collision setup.
* Implemented a new `createCollision` method that identifies platform layers within the ground layers, sets collision properties on tiles with the `collider` property, and converts them for use with the Matter physics engine.
* Updated the `build` method to call `createCollision` after world layers are created, ensuring collision is configured during map initialization.

**Layer management changes:**
* Modified `createWorldLayers` to assign the result of the ground layer creation to the new `ground` property for later access in collision setup.
	
</details>


---


#### Evidence

<details>
	<summary>
⏪️ | Before
	</summary>

<img width="1310" height="872" alt="image" src="https://github.com/user-attachments/assets/ed839945-0dc9-44d8-9d72-32b6e9dfb2cb" />

</details>

<details>
	<summary>
⏩ | After
	</summary>

<img width="1310" height="872" alt="image" src="https://github.com/user-attachments/assets/353f7a5c-9fa6-49b3-b0f0-9a42d88b13dd" />

</details>

---

#### Rollback Plan

Revert from the branch.