### PR TITLE
061 | State - Part 8: Create Airborne and Ground Helpers

### DIFF
--- a/packages/client/src/game/ecs/systems/state/handlers/player/helpers/airborne/AirborneHandler.ts
+++ b/packages/client/src/game/ecs/systems/state/handlers/player/helpers/airborne/AirborneHandler.ts
@@ -1,0 +1,18 @@
+import { CHARACTER_STATE } from '@/config/constants';
+import { resolveCombat } from '../combat';
+import { AirborneHandlerResolveProp } from './types.p';
+
+class AirborneHandler {
+  resolve({ state, input }: AirborneHandlerResolveProp): void {
+    const combat = resolveCombat({ input });
+
+    if (combat) {
+      state.characterState = combat.characterState;
+      return;
+    }
+
+    state.characterState = CHARACTER_STATE.JUMP;
+  }
+}
+
+export { AirborneHandler };

--- a/packages/client/src/game/ecs/systems/state/handlers/player/helpers/airborne/index.ts
+++ b/packages/client/src/game/ecs/systems/state/handlers/player/helpers/airborne/index.ts
@@ -1,0 +1,1 @@
+export * from './AirborneHandler';

--- a/packages/client/src/game/ecs/systems/state/handlers/player/helpers/airborne/types.p.ts
+++ b/packages/client/src/game/ecs/systems/state/handlers/player/helpers/airborne/types.p.ts
@@ -1,0 +1,8 @@
+import { InputComponent, StateComponent } from '@/ecs/components';
+
+type AirborneHandlerResolveProp = {
+  state: StateComponent;
+  input: InputComponent;
+};
+
+export type { AirborneHandlerResolveProp };

--- a/packages/client/src/game/ecs/systems/state/handlers/player/helpers/grounded/GroundedHandler.ts
+++ b/packages/client/src/game/ecs/systems/state/handlers/player/helpers/grounded/GroundedHandler.ts
@@ -1,0 +1,33 @@
+import { CHARACTER_STATE } from '@/config/constants';
+import { resolveCombat } from '../combat';
+import { GroundedHandlerResolveProp } from './types.p';
+
+class GroundedHandler {
+  resolve({ state, input }: GroundedHandlerResolveProp): void {
+    const combat = resolveCombat({ input });
+
+    if (combat) {
+      state.characterState = combat.characterState;
+      return;
+    }
+
+    if (input.left || input.right) {
+      state.characterState = CHARACTER_STATE.RUN;
+      return;
+    }
+
+    if (input.up) {
+      state.characterState = CHARACTER_STATE.LOOK_UP;
+      return;
+    }
+
+    if (input.down) {
+      state.characterState = CHARACTER_STATE.LOOK_DOWN;
+      return;
+    }
+
+    state.characterState = CHARACTER_STATE.IDLE;
+  }
+}
+
+export { GroundedHandler };

--- a/packages/client/src/game/ecs/systems/state/handlers/player/helpers/grounded/index.ts
+++ b/packages/client/src/game/ecs/systems/state/handlers/player/helpers/grounded/index.ts
@@ -1,0 +1,1 @@
+export * from './GroundedHandler';

--- a/packages/client/src/game/ecs/systems/state/handlers/player/helpers/grounded/types.p.ts
+++ b/packages/client/src/game/ecs/systems/state/handlers/player/helpers/grounded/types.p.ts
@@ -1,0 +1,8 @@
+import { InputComponent, StateComponent } from '@/ecs/components';
+
+type GroundedHandlerResolveProp = {
+  state: StateComponent;
+  input: InputComponent;
+};
+
+export type { GroundedHandlerResolveProp };


### PR DESCRIPTION
## Information

#### Describe What Was Done

- Create both `Airborne` and `Grounded` helpers inside `/state/handlers/player` to follow the new handlers structures.

---

#### Detailed Summary (AI Generated)


<details>
	<summary>
🤖| Summary	</summary>
<br />

This Pull Request introduces new state management handlers for managing player states in a game environment based on their conditions (airborne or grounded).

### **New Player State Handlers**
- Added `AirborneHandler` in `AirborneHandler.ts`:
  - Defines a `resolve` method to update the player state based on combat state or sets the state to `CHARACTER_STATE.JUMP` by default.
- Added `GroundedHandler` in `GroundedHandler.ts`:
  - Defines a `resolve` method to determine the player's state (e.g., `RUN`, `LOOK_UP`, `LOOK_DOWN`, `IDLE`) based on input or combat state.

### **Supporting Files**
- Created `index.ts` files for both `airborne` and `grounded` handlers to export relevant classes:
  - `airborne/index.ts` exports `AirborneHandler`.
  - `grounded/index.ts` exports `GroundedHandler`.
- Defined type files for the handlers:
  - `airborne/types.p.ts`: Introduced the `AirborneHandlerResolveProp` type with `state` and `input` properties for use in `AirborneHandler`.
  - `grounded/types.p.ts`: Introduced the `GroundedHandlerResolveProp` type with `state` and `input` properties for use in `GroundedHandler`.

These changes enhance the game's ECS state handling for player actions by adding specific logic for airborne and grounded scenarios.
	
</details>

---

#### Diagrams

<details>
	<summary>
📈 | Flowchart - No changes yet
	</summary>
	





</details>




---


#### Evidence

<details>
	<summary>
⏪️ | Before - No changes yet
	</summary>







</details>
<details>
	<summary>
⏩ | After - No visual changes yet
	</summary>






</details>

---

#### Rollback Plan

Revert from the branch.


---

↗️ | **[Click to See The Preview](https://vulpy-labs.github.io/slash-out/preview/pr-61)**