### PR TITLE
069 | CI - Update PR Summary on every commit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,9 @@ _“Let there be light, and there was light." 💡_
 <br />
 
 <!-- AI-SUMMARY-START -->
+
 [Summary Placeholder: _"beep beep boop boop"_]
+
 <!-- AI-SUMMARY-END -->
 
 </details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,8 +14,10 @@ _“Let there be light, and there was light." 💡_
 🤖| Summary	</summary>
 <br />
 
+<!-- AI-SUMMARY-START -->
 [Summary Placeholder: _"beep beep boop boop"_]
-	
+<!-- AI-SUMMARY-END -->
+
 </details>
 
 ---

--- a/.github/workflows/pr-summary.yml
+++ b/.github/workflows/pr-summary.yml
@@ -12,7 +12,8 @@ on:
 
 env:
   PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pull_number || github.event.pull_request.number }}
-  SUMMARY_PLACEHOLDER: '[Summary Placeholder: _"beep beep boop boop"_]'
+  AI_SUMMARY_START: '<!-- AI-SUMMARY-START -->'
+  AI_SUMMARY_END: '<!-- AI-SUMMARY-END -->'
   SKIPPABLE_EXTENSIONS: '[".excalidraw"]'
 
 jobs:
@@ -65,11 +66,10 @@ jobs:
 
             try {
               const { body = "" } = JSON.parse(process.env.PR_DATA);
-              const hasPlaceholder = body.includes(process.env.SUMMARY_PLACEHOLDER);
+              const hasSentinels = body.includes(process.env.AI_SUMMARY_START) && body.includes(process.env.AI_SUMMARY_END);
 
-              if (!hasPlaceholder) {
-                console.log('Placeholder not found. PR summary might already exist.');
-
+              if (!hasSentinels) {
+                console.log('Summary sentinels not found. Skipping.');
                 return false;
               }
 
@@ -96,7 +96,7 @@ jobs:
 
               const trimmedFiles = files.map(({ filename, patch }) => ({ filename, patch }));
               core.setOutput('files', JSON.stringify(trimmedFiles));
-              console.log('Placeholder found and PR has non-skippable files. Summary will be created.');
+              console.log('Sentinels found and PR has non-skippable files. Summary will be created.');
               return true;
             } catch (error) {
               throw new Error(`Error while deciding if summary should be created: ${error.message}`);
@@ -170,7 +170,10 @@ jobs:
           script: |
             try {
               const { body = "" } = JSON.parse(process.env.PR_DATA);
-              const newBody = body.replace(process.env.SUMMARY_PLACEHOLDER, process.env.NEW_SUMMARY);
+              const newBody = body.replace(
+                new RegExp(`${process.env.AI_SUMMARY_START}[\\s\\S]*?${process.env.AI_SUMMARY_END}`),
+                `${process.env.AI_SUMMARY_START}\n${process.env.NEW_SUMMARY}\n${process.env.AI_SUMMARY_END}`
+              );
 
               await github.rest.pulls.update({
                 owner: context.repo.owner,

--- a/.github/workflows/pr-summary.yml
+++ b/.github/workflows/pr-summary.yml
@@ -172,7 +172,7 @@ jobs:
               const { body = "" } = JSON.parse(process.env.PR_DATA);
               const newBody = body.replace(
                 new RegExp(`${process.env.AI_SUMMARY_START}[\\s\\S]*?${process.env.AI_SUMMARY_END}`),
-                `${process.env.AI_SUMMARY_START}\n${process.env.NEW_SUMMARY}\n${process.env.AI_SUMMARY_END}`
+                () => `${process.env.AI_SUMMARY_START}\n${process.env.NEW_SUMMARY}\n${process.env.AI_SUMMARY_END}`
               );
 
               await github.rest.pulls.update({

--- a/.github/workflows/pr-summary.yml
+++ b/.github/workflows/pr-summary.yml
@@ -170,9 +170,13 @@ jobs:
           script: |
             try {
               const { body = "" } = JSON.parse(process.env.PR_DATA);
+              const summary = process.env.NEW_SUMMARY
+                .replaceAll(process.env.AI_SUMMARY_START, '')
+                .replaceAll(process.env.AI_SUMMARY_END, '');
+
               const newBody = body.replace(
                 new RegExp(`${process.env.AI_SUMMARY_START}[\\s\\S]*?${process.env.AI_SUMMARY_END}`),
-                () => `${process.env.AI_SUMMARY_START}\n${process.env.NEW_SUMMARY}\n${process.env.AI_SUMMARY_END}`
+                () => `${process.env.AI_SUMMARY_START}\n${summary}\n${process.env.AI_SUMMARY_END}`
               );
 
               await github.rest.pulls.update({


### PR DESCRIPTION
## Information

#### Describe What Was Done

- Update the GitHub Action workflow to generate a new summary automatically after every new commit.

---

#### Detailed Summary (AI Generated)


<details>
	<summary>
🤖| Summary	</summary>
<br />

<!-- AI-SUMMARY-START -->
This PR updates the GitHub workflow and template files to improve automated PR summaries by replacing the placeholder mechanism with start and end sentinel markers.

### **Pull Request Template Updates**
- Modified `.github/pull_request_template.md`:
  - Replaced the existing summary placeholder string with start (``) and end (``) sentinel markers for identifying where an automated summary should be injected.

### **GitHub Workflow Changes**
- Updated `.github/workflows/pr-summary.yml`:
  - Replaced the `SUMMARY_PLACEHOLDER` environment variable with new `AI_SUMMARY_START` and `AI_SUMMARY_END` variables to use the sentinel tags in PR bodies.
  - Updated logic to detect and process summaries:
    - Replaced checks for a single placeholder string with checks for both start and end sentinel markers in the PR body.
    - Adjusted logging to reflect the updated sentinel mechanism.
    - Added functionality to replace the content enclosed by sentinel markers in the PR body with the newly generated summary.
    - Stripped any redundant sentinel markers from the generated summary itself to prevent nested tags. 

These changes unify and enhance the workflow for handling automated PR summaries, improving consistency and reducing potential errors related to placeholder detection and replacement.
<!-- AI-SUMMARY-END -->

</details>




---


#### Evidence

<details>
	<summary>
⏪️ | Before
	</summary>


The workflow usually skipped subsequent runs after the first summary generation




</details>
<details>
	<summary>
⏩ | After
	</summary>

Job skipped when no sentinel commentary is found

<img width="1900" height="507" alt="image" src="https://github.com/user-attachments/assets/da075e86-5ccb-459c-9d04-cf359e8e2fde" />

Summary created when PR was opened

<img width="1038" height="687" alt="image" src="https://github.com/user-attachments/assets/1b219efd-8d3e-47fc-af63-3ad196b72d0c" />


Summary created after test commit:

<img width="1041" height="692" alt="image" src="https://github.com/user-attachments/assets/9b9caa63-e1f3-48fe-8111-c291d6c8dbc0" />


</details>

---

#### Rollback Plan

Revert from the branch.


---

↗️ | **[Click to See The Preview](https://vulpy-labs.github.io/slash-out/preview/pr-73)**