### PR TITLE
070 | CI - Close previous weekly reports before opening new ones

### DIFF
--- a/.github/workflows/weekly-repo-status.lock.yml
+++ b/.github/workflows/weekly-repo-status.lock.yml
@@ -28,7 +28,7 @@
 #
 # Source: githubnext/agentics/workflows/weekly-repo-status.md@acea14d65af123c315230221b409f4f435b3706f
 #
-# frontmatter-hash: 80bfd2b9a3e3e58770c22fe13869d28dbe535af26a2dede1fcf4194f1ca1710b
+# frontmatter-hash: 89f0cbf2f3b24755611af7d1e92d60e812b93e6d708627237cc0d494b8dce66b
 
 name: "Weekly Repo Status"
 "on":
@@ -345,7 +345,7 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"create_issue":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"close_issue":{"max":10,"required_labels":["weekly-status"],"required_title_prefix":"[repo-status] ","target":"*"},"create_issue":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
@@ -389,6 +389,30 @@ jobs:
                 "type": "object"
               },
               "name": "create_issue"
+            },
+            {
+              "description": "Close a GitHub issue with a closing comment. You can and should always add a comment when closing an issue to explain the action or provide context. This tool is ONLY for closing issues - use update_issue if you need to change the title, body, labels, or other metadata without closing. Use close_issue when work is complete, the issue is no longer relevant, or it's a duplicate. The closing comment should explain the resolution or reason for closing. If the issue is already closed, a comment will still be posted. CONSTRAINTS: Maximum 10 issue(s) can be closed. Target: *.",
+              "inputSchema": {
+                "additionalProperties": false,
+                "properties": {
+                  "body": {
+                    "description": "Closing comment explaining why the issue is being closed and summarizing any resolution, workaround, or conclusion.",
+                    "type": "string"
+                  },
+                  "issue_number": {
+                    "description": "Issue number to close. This is the numeric ID from the GitHub URL (e.g., 901 in github.com/owner/repo/issues/901). If omitted, closes the issue that triggered this workflow (requires an issue event trigger).",
+                    "type": [
+                      "number",
+                      "string"
+                    ]
+                  }
+                },
+                "required": [
+                  "body"
+                ],
+                "type": "object"
+              },
+              "name": "close_issue"
             },
             {
               "description": "Report that a tool or capability needed to complete the task is not available, or share any information you deem important about missing functionality or limitations. Use this when you cannot accomplish what was requested because the required functionality is missing or access is restricted.",
@@ -463,6 +487,20 @@ jobs:
           GH_AW_SAFE_OUTPUTS_TOOLS_EOF
           cat > /opt/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_EOF'
           {
+            "close_issue": {
+              "defaultMax": 1,
+              "fields": {
+                "body": {
+                  "required": true,
+                  "type": "string",
+                  "sanitize": true,
+                  "maxLength": 65000
+                },
+                "issue_number": {
+                  "optionalPositiveInteger": true
+                }
+              }
+            },
             "create_issue": {
               "defaultMax": 1,
               "fields": {
@@ -1038,7 +1076,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"report\",\"weekly-status\"],\"max\":1,\"title_prefix\":\"[repo-status] \"},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"close_issue\":{\"max\":10,\"required_labels\":[\"weekly-status\"],\"required_title_prefix\":\"[repo-status] \",\"target\":\"*\"},\"create_issue\":{\"labels\":[\"report\",\"weekly-status\"],\"max\":1,\"title_prefix\":\"[repo-status] \"},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/weekly-repo-status.md
+++ b/.github/workflows/weekly-repo-status.md
@@ -29,7 +29,6 @@ safe-outputs:
     required-labels: [weekly-status]
     required-title-prefix: "[repo-status] "
     max: 10
-    state-reason: "not_planned"
   create-issue:
     title-prefix: "[repo-status] "
     labels: [report, weekly-status]

--- a/.github/workflows/weekly-repo-status.md
+++ b/.github/workflows/weekly-repo-status.md
@@ -24,6 +24,12 @@ tools:
     lockdown: false
 
 safe-outputs:
+  close-issue:
+    target: "*"
+    required-labels: [weekly-status]
+    required-title-prefix: "[repo-status] "
+    max: 10
+    state-reason: "not_planned"
   create-issue:
     title-prefix: "[repo-status] "
     labels: [report, weekly-status]
@@ -52,6 +58,7 @@ Create an upbeat weekly status report for the repo as a GitHub issue.
 
 ## Process
 
-1. Gather recent activity from the repository
-2. Study the repository, its issues and its pull requests
-3. Create a new GitHub issue with your findings and insights
+1. Close any previously open weekly status issues (label: `weekly-status`, title prefix: `[repo-status]`)
+2. Gather recent activity from the repository
+3. Study the repository, its issues and its pull requests
+4. Create a new GitHub issue with your findings and insights


### PR DESCRIPTION
## Information

#### Describe What Was Done

- Update workflow to close previous weekly reports before opening the new one

---

#### Detailed Summary (AI Generated)


<details>
	<summary>
🤖| Summary	</summary>
<br />

<!-- AI-SUMMARY-START -->
This PR introduces updates and new features to the `weekly-repo-status` workflow for improved issue management.

### **Workflow Enhancements**
- **Configuration Updates**:
  - Updated the `frontmatter-hash` in `.github/workflows/weekly-repo-status.lock.yml` to ensure the workflow is aligned with the latest configuration changes.
  - Modified the `GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG` to include a new `close_issue` action with constraints such as maximum closures (10), required labels (`weekly-status`), a required title prefix (`[repo-status]`), and a target (`*`).

- **New "close_issue" Tool**:
  - Added support for a new `close_issue` tool, which allows closing GitHub issues programmatically.
  - Defined an input schema requiring a closing `body` description, issue `issue_number` (optional if triggered by an issue event), and other constraints like character limits for the description (maxLength: 65000 characters).
  - Updated `safeoutputs` configuration to handle the `close_issue` tool with validation rules for issue numbers and required body text sanitization.

### **Documentation Updates**
- `.github/workflows/weekly-repo-status.md`:
  - Added a description of the new `close_issue` tool, its constraints, and usage requirements (e.g., required label `weekly-status`, required title prefix `[repo-status]`).
  - Updated the process workflow to include a new step: closing any previously open weekly status issues that match the label `weekly-status` and title prefix `[repo-status]`.

These changes enhance the automation capabilities of the weekly repository status workflow by introducing issue closure functionality and improving configuration flexibility.
<!-- AI-SUMMARY-END -->

</details>

---


#### Evidence

<details>
	<summary>
⏪️ | Before - Issues open
	</summary>



<img width="1478" height="886" alt="image" src="https://github.com/user-attachments/assets/d5a2ac22-fa02-4990-8c27-9f5291322026" />




</details>
<details>
	<summary>
⏩ | After
	</summary>


Only one weekly report is open

<img width="1283" height="306" alt="image" src="https://github.com/user-attachments/assets/b95bff5a-a47b-41a3-9265-a5719bebc090" />


Previous weekly reports closed

<img width="1335" height="891" alt="image" src="https://github.com/user-attachments/assets/5b0071eb-14bd-4e62-a0a3-a3207882605f" />




</details>

---

#### Rollback Plan

Revert from the branch.


---

↗️ | **[Click to See The Preview](https://vulpy-labs.github.io/slash-out/preview/pr-74)**