### PR TITLE
079 | Combat - Part 4: Add sword animation

### DIFF
--- a/docs/client/game/builders/weapon/WeaponBuilder.md
+++ b/docs/client/game/builders/weapon/WeaponBuilder.md
@@ -54,7 +54,8 @@ Factory for creating weapon entities through registered handlers.
 
 1. **Initialization:**
    - Creates handler map
-   - Registers default handlers (Sword)
+   - Registers default handlers:
+     - `ENTITY_TYPES.SWORD` mapped to `SwordWeaponHandler`
 2. **Loading:**
    - Delegates to handler's load()
 3. **Building:**

--- a/docs/client/game/builders/weapon/handlers/sword/SwordWeaponHandler.md
+++ b/docs/client/game/builders/weapon/handlers/sword/SwordWeaponHandler.md
@@ -1,4 +1,4 @@
-# SwordWeaponHandler Documentation
+# Sword Weapon Handler Documentation
 
 ## Overview
 Handles loading and building sword weapon entities in the game. Responsible for creating sword sprites with Matter.js physics and setting up their initial state.

--- a/docs/client/game/builders/weapon/handlers/sword/SwordWeaponHandler.md
+++ b/docs/client/game/builders/weapon/handlers/sword/SwordWeaponHandler.md
@@ -1,0 +1,62 @@
+# SwordWeaponHandler Documentation
+
+## Overview
+Handles loading and building sword weapon entities in the game. Responsible for creating sword sprites with Matter.js physics and setting up their initial state.
+
+## Technical Identity
+- **Type:** Handler
+- **Domain:** Weapon/Combat
+
+## Responsibilities
+- Loads sword sprite assets
+- Creates sword entities with physics properties
+- Configures sword display and collision properties
+- Links swords to their owners via entity IDs
+
+## Data Schema
+
+### Manipulated Components
+- **Writes:**
+  - `StateComponent`: Sets initial sword state (IDLE)
+  - `InputComponent`: Provides default input mapping
+  - `KeymapComponent`: Configures key bindings based on owner
+  - `AnimationComponent`: Sets up sword animations
+
+### Configuration Props
+- `load`:
+  - `scene`: Phaser.Scene - Scene context for loading assets
+- `build`:
+  - `scene`: Phaser.Scene - Scene context for sprite creation
+  - `x`: number - Initial x position
+  - `y`: number - Initial y position
+  - `ownerEntityId`: string - ID of entity owning this sword
+
+## Lifecycle & Execution Flow
+1. **Initialization:** Loads sprite assets via `load()`
+2. **Build:** Creates Matter.js sprite with physics properties
+3. **Runtime:** Maintains sword state and animation
+
+## Methods
+
+### `load({ scene }: { scene: Phaser.Scene }): void`
+Loads sword sprite assets if they don't already exist in texture cache.
+
+### `build({ scene, x, y, ownerEntityId }): GlobalEntity`
+Creates and configures a sword entity with:
+- Physics body
+- Display properties
+- Initial state
+- Owner reference
+
+## Dependencies & Relationships
+- **Core Dependencies:** 
+  - Phaser.Scene
+  - Phaser.Physics.Matter.Sprite
+  - MatterJS.BodyType
+- **Related Systems:**
+  - AnimationSystem: Handles sword animations
+  - StateSystem: Manages sword state transitions
+
+## Maintenance Notes
+> [!WARNING]
+> **Performance:** Uses sensor physics bodies for collision detection without physical interactions.

--- a/docs/client/game/builders/weapon/handlers/sword/SwordWeaponHandler.md
+++ b/docs/client/game/builders/weapon/handlers/sword/SwordWeaponHandler.md
@@ -48,9 +48,14 @@ Handles loading and building sword weapon entities with Matter.js physics.
 
 1. **Loading:**
    - Loads 5 sword sprite variants (spr_sword_0 to spr_sword_4)
+     - Checks if texture already exists before loading
+     - Uses PNG format for all sprites
 2. **Building:**
    - Creates Matter.js sprite
-   - Configures physics body as sensor
+   - Configures physics body as sensor:
+     - Rectangle shape matching sprite dimensions
+     - No collision response
+     - Ignores gravity
    - Sets visual properties
    - Returns GlobalEntity
 

--- a/docs/client/game/ecs/components/animation/AnimationComponent.md
+++ b/docs/client/game/ecs/components/animation/AnimationComponent.md
@@ -51,7 +51,9 @@ N/A (Pure data interface)
 
 ## Dependencies & Relationships
 
-- **Core Dependencies:** `CHARACTER_STATE`
+- **Core Dependencies:** 
+  - `CHARACTER_STATE`
+  - `SWORD_STATE`
 - **Related Systems:**
   - `AnimationSystem`: Handles playback
   - `StateSystem`: Triggers state changes

--- a/docs/client/game/ecs/entities/sword/SwordEntity.md
+++ b/docs/client/game/ecs/entities/sword/SwordEntity.md
@@ -28,6 +28,7 @@ Defines the component structure for sword entities.
 - `input`: InputComponent - Tracks input state
 - `state`: StateComponent - Manages current state
 - `sprite`: Phaser.Physics.Matter.Sprite - Visual representation
+- `animation`: AnimationComponent - Handles animations
 
 ### Inherited Components
 

--- a/docs/client/game/ecs/entities/sword/SwordEntity.md
+++ b/docs/client/game/ecs/entities/sword/SwordEntity.md
@@ -1,4 +1,4 @@
-# SwordEntity Documentation
+# Sword Entity Documentation
 
 ## Overview
 Defines the structure and components of sword entities in the ECS architecture.

--- a/docs/client/game/ecs/entities/sword/SwordEntity.md
+++ b/docs/client/game/ecs/entities/sword/SwordEntity.md
@@ -1,0 +1,28 @@
+# SwordEntity Documentation
+
+## Overview
+Defines the structure and components of sword entities in the ECS architecture.
+
+## Technical Identity
+- **Type:** Entity
+- **Domain:** Combat/Weapons
+
+## Data Schema
+### Component Composition
+- `keymap`: KeymapComponent - Input key bindings
+- `input`: InputComponent - Current input state
+- `state`: StateComponent - Current sword state (IDLE/SLASHING)
+- `sprite`: Phaser.Physics.Matter.Sprite - Visual representation
+- `animation`: AnimationComponent - Animation configurations
+
+## Relationships
+- **Owned By:** Player entities via ownerEntityId
+- **Managed By:** EntityManager
+- **Processed By:**
+  - SwordStateHandler: Updates sword state
+  - AnimationSystem: Handles animations
+  - InputSystem: Processes player input
+
+## Maintenance Notes
+> [!NOTE]
+> Sword entities are created exclusively through the SwordWeaponHandler builder.

--- a/docs/client/game/utils/factories/ecs/components/animation/sword/defaultSwordAnimation.md
+++ b/docs/client/game/utils/factories/ecs/components/animation/sword/defaultSwordAnimation.md
@@ -1,0 +1,83 @@
+# defaultSwordAnimation Documentation
+
+## Overview
+
+Factory function that creates default animation configurations for sword entities.
+
+---
+
+## Technical Identity
+
+- **Type:** Factory
+- **Domain:** Animation Configuration
+
+---
+
+## Responsibilities
+
+- Defines idle and slashing animations for swords
+- Provides animation frame sequences
+- Configures animation properties (repeat, frame rate)
+
+---
+
+## Data Schema
+
+### Manipulated Components
+
+- **Reads:** N/A
+- **Writes:** N/A
+- **Creates:**
+  - `AnimationComponent` with sword animations
+
+### Animation Properties
+
+- `key`: Animation identifier
+- `start`: Starting frame index
+- `end`: Ending frame index
+- `repeat`: Whether animation loops
+- `frameRate`: Playback speed
+- `frames`: Array of sprite frames
+
+---
+
+## Lifecycle & Execution Flow
+
+1. **Initialization:** Called during sword entity creation
+2. **Execution:** Returns preconfigured animation component
+3. **Teardown:** N/A
+
+---
+
+## Methods
+
+### `defaultSwordAnimation()`
+
+**Description:** Creates sword animation component
+
+**Flow:**
+- Defines idle animation (single frame)
+- Defines slashing animation (5-frame sequence)
+- Returns animation component
+
+**Side Effects:**
+- None (pure function)
+
+---
+
+## Dependencies & Relationships
+
+- **Core Dependencies:**
+  - `SWORD_STATE`: Defines animation states
+  - `AnimationComponent`: Return type
+- **Related Systems:**
+  - `AnimationSystem`: Uses created animations
+  - `SwordWeaponHandler`: Calls factory during entity creation
+- **Events Consumed/Emitted:** N/A
+
+---
+
+## Maintenance Notes
+
+> [!NOTE]  
+> **Performance:** Frame indices must match loaded sprite textures exactly

--- a/docs/client/game/utils/factories/ecs/components/animation/sword/defaultSwordAnimation.md
+++ b/docs/client/game/utils/factories/ecs/components/animation/sword/defaultSwordAnimation.md
@@ -56,8 +56,10 @@ Factory function that creates default animation configurations for sword entitie
 **Description:** Creates sword animation component
 
 **Flow:**
-- Defines idle animation (single frame)
-- Defines slashing animation (5-frame sequence)
+- Defines idle animation (single frame, `spr_sword_0`)
+- Defines slashing animation (5-frame sequence, `spr_sword_0` to `spr_sword_4`)
+  - Frame rate: 15 FPS
+  - Non-repeating
 - Returns animation component
 
 **Side Effects:**

--- a/packages/client/src/game/builders/weapon/handlers/sword/SwordWeaponHandler.ts
+++ b/packages/client/src/game/builders/weapon/handlers/sword/SwordWeaponHandler.ts
@@ -1,6 +1,10 @@
 import { DEPTH, ENTITY_TYPES, SWORD, SWORD_STATE } from '@/config/constants';
 import { GlobalEntity } from '@/ecs/entities';
-import { defaultInput, defaultKeymap, defaultSwordAnimation } from '@/utils/factories/ecs/components';
+import {
+  defaultInput,
+  defaultKeymap,
+  defaultSwordAnimation,
+} from '@/utils/factories/ecs/components';
 import { IWeaponHandler } from '../types.i';
 
 export class SwordWeaponHandler implements IWeaponHandler {

--- a/packages/client/src/game/builders/weapon/handlers/sword/SwordWeaponHandler.ts
+++ b/packages/client/src/game/builders/weapon/handlers/sword/SwordWeaponHandler.ts
@@ -1,6 +1,6 @@
 import { DEPTH, ENTITY_TYPES, SWORD, SWORD_STATE } from '@/config/constants';
 import { GlobalEntity } from '@/ecs/entities';
-import { defaultInput, defaultKeymap } from '@/utils/factories/ecs/components';
+import { defaultInput, defaultKeymap, defaultSwordAnimation } from '@/utils/factories/ecs/components';
 import { IWeaponHandler } from '../types.i';
 
 export class SwordWeaponHandler implements IWeaponHandler {
@@ -48,6 +48,7 @@ export class SwordWeaponHandler implements IWeaponHandler {
       state: { current: SWORD_STATE.IDLE },
       input: defaultInput(),
       keymap: defaultKeymap({ player: playerRef }),
+      animation: defaultSwordAnimation(),
     };
   }
 }

--- a/packages/client/src/game/ecs/components/animation/AnimationComponent.ts
+++ b/packages/client/src/game/ecs/components/animation/AnimationComponent.ts
@@ -1,6 +1,6 @@
-import { CharacterState } from '@/config/constants';
+import { CharacterState, SwordState } from '@/config/constants';
 
-type AnimationState = CharacterState;
+type AnimationState = CharacterState | SwordState;
 
 type Animation = {
   key: string;

--- a/packages/client/src/game/ecs/entities/sword/SwordEntity.ts
+++ b/packages/client/src/game/ecs/entities/sword/SwordEntity.ts
@@ -1,4 +1,9 @@
-import { AnimationComponent, InputComponent, KeymapComponent, StateComponent } from '@/ecs/components';
+import {
+  AnimationComponent,
+  InputComponent,
+  KeymapComponent,
+  StateComponent,
+} from '@/ecs/components';
 import { BaseEntity } from '../base';
 
 interface SwordEntity extends BaseEntity {

--- a/packages/client/src/game/ecs/entities/sword/SwordEntity.ts
+++ b/packages/client/src/game/ecs/entities/sword/SwordEntity.ts
@@ -1,4 +1,4 @@
-import { InputComponent, KeymapComponent, StateComponent } from '@/ecs/components';
+import { AnimationComponent, InputComponent, KeymapComponent, StateComponent } from '@/ecs/components';
 import { BaseEntity } from '../base';
 
 interface SwordEntity extends BaseEntity {
@@ -6,6 +6,7 @@ interface SwordEntity extends BaseEntity {
   input: InputComponent;
   state: StateComponent;
   sprite: Phaser.Physics.Matter.Sprite;
+  animation: AnimationComponent;
 }
 
 export type { SwordEntity };

--- a/packages/client/src/game/utils/factories/ecs/components/animation/index.ts
+++ b/packages/client/src/game/utils/factories/ecs/components/animation/index.ts
@@ -1,1 +1,2 @@
 export * from './player';
+export * from './sword';

--- a/packages/client/src/game/utils/factories/ecs/components/animation/sword/defaultSwordAnimation.ts
+++ b/packages/client/src/game/utils/factories/ecs/components/animation/sword/defaultSwordAnimation.ts
@@ -1,0 +1,33 @@
+import { SWORD_STATE } from '@/config/constants';
+import { AnimationComponent } from '@/ecs/components';
+
+function defaultSwordAnimation(): AnimationComponent {
+  return {
+    animations: {
+      [SWORD_STATE.IDLE]: {
+        key: 'spr_sword_idle',
+        start: 0,
+        end: 0,
+        repeat: true,
+        frameRate: 1,
+        frames: [{ key: 'spr_sword_0' }],
+      },
+      [SWORD_STATE.SLASHING]: {
+        key: 'spr_sword_slashing',
+        start: 0,
+        end: 4,
+        repeat: false,
+        frameRate: 15,
+        frames: [
+          { key: 'spr_sword_0' },
+          { key: 'spr_sword_1' },
+          { key: 'spr_sword_2' },
+          { key: 'spr_sword_3' },
+          { key: 'spr_sword_4' },
+        ],
+      },
+    },
+  };
+}
+
+export { defaultSwordAnimation };

--- a/packages/client/src/game/utils/factories/ecs/components/animation/sword/index.ts
+++ b/packages/client/src/game/utils/factories/ecs/components/animation/sword/index.ts
@@ -1,0 +1,1 @@
+export * from './defaultSwordAnimation';


### PR DESCRIPTION
## Information

#### Describe What Was Done

- Add frames logic to play animation when the player presses the slash button.

---

#### Detailed Summary (AI Generated)


<details>
	<summary>
🤖| Summary	</summary>
<br />

<!-- AI-SUMMARY-START -->
This pull request adds animation support to the sword entity within the client game's Entity Component System (ECS). It introduces a default animation factory for swords and integrates animation properties into the sword entity and handler definitions.

**ECS Component & Entity Updates**
- Extended the `AnimationComponent` type definition to accept `SwordState` alongside `CharacterState`.
- Added the `animation` property (`AnimationComponent`) to the `SwordEntity` interface.
- Updated `SwordWeaponHandler` to instantiate and assign default sword animations during entity setup.

**New Animation Factory**
- Created the `defaultSwordAnimation` factory function to define frame configurations and rates for `IDLE` and `SLASHING` sword states.
- Exported the new sword animation module through the ECS component factory index files.
<!-- AI-SUMMARY-END -->

</details>

---


#### Evidence

<details>
	<summary>
⏪️ | Before - No animation to show
	</summary>







</details>
<details>
	<summary>
⏩ | After - Animation Playing
	</summary>




https://github.com/user-attachments/assets/cb9823b8-e8a1-4a78-987c-d7a02b72a58b




</details>

---

#### Rollback Plan

Revert from the branch.


---

↗️ | **[Click to See The Preview](https://vulpy-labs.github.io/slash-out/preview/pr-86)**