### PR TITLE
080 | Combat - Part 5: Prevent sword attack spamming

### DIFF
--- a/docs/client/game/builders/weapon/WeaponBuilder.md
+++ b/docs/client/game/builders/weapon/WeaponBuilder.md
@@ -34,19 +34,18 @@ Factory for creating weapon entities through registered handlers.
 
 ### Constants Used
 
-- `ENTITY_TYPES`: Defines weapon entity types
+- `ENTITY_TYPES`: Defines weapon entity types (currently only `SWORD` supported)
 
 ### Configuration Props
 
 - `WeaponBuilderProp`:
-- `WeaponEntityTypes`: Union type of supported weapon types
   - `scene: Phaser.Scene`
-  - `onEntityCreated: OnEntityCreatedCallback`
+  - `onEntityCreated: (entity: GlobalEntity) => void`
 - `WeaponBuilderBuildProp`:
   - `x: number`
   - `y: number`  
   - `ownerEntityId: string`
-  - `entityType: WeaponEntityTypes`
+  - `entityType: WeaponEntityTypes` (currently only `ENTITY_TYPES.SWORD`)
 
 ---
 
@@ -58,9 +57,11 @@ Factory for creating weapon entities through registered handlers.
      - `ENTITY_TYPES.SWORD` mapped to `SwordWeaponHandler`
 2. **Loading:**
    - Delegates to handler's load()
+   - Throws error if handler not found: `No weapon builder handler found for entity type: ${entityType}`
 3. **Building:**
    - Delegates to handler's build()
-   - Invokes onEntityCreated callback
+   - Throws error if handler not found: `No weapon builder handler found for entity type: ${entityType}`
+   - Invokes onEntityCreated callback with built entity
 
 ---
 
@@ -68,7 +69,7 @@ Factory for creating weapon entities through registered handlers.
 
 ### `constructor({ scene, onEntityCreated })`
 
-**Description:** Initializes builder
+**Description:** Initializes builder with scene reference and entity creation callback
 
 **Flow:**
 - Stores scene reference
@@ -78,37 +79,38 @@ Factory for creating weapon entities through registered handlers.
 
 ### `load({ entityType })`
 
-**Description:** Loads weapon assets
+**Description:** Loads weapon assets via registered handler
 
 **Flow:**
-- Gets handler by type
-- Throws if not found
+- Gets handler by type from map
+- Throws error if handler not found
 - Delegates to handler.load()
 
 **Side Effects:**
-- Loads assets via Phaser
+- Loads assets via Phaser's scene loader
 
 ### `build({ x, y, ownerEntityId, entityType })`
 
-**Description:** Creates weapon entity
+**Description:** Creates weapon entity via registered handler
 
 **Flow:**
-- Gets handler by type
-- Throws if not found
+- Gets handler by type from map
+- Throws error if handler not found
 - Delegates to handler.build()
-- Invokes callback with entity
+- Invokes callback with created entity
 
 **Side Effects:**
-- Creates new entity
-- Notifies EntityManager
+- Creates new entity with physics body
+- Notifies EntityManager via callback
 
 ---
 
 ## Dependencies & Relationships
 
 - **Core Dependencies:**
-  - `IWeaponHandler` interface
+  - `IWeaponHandler` interface (load/build methods)
   - `SwordWeaponHandler` implementation
+  - `GlobalEntity` type
 - **Related Systems:**
   - `EntityManager`: Receives created entities
   - `AnimationSystem`: Handles weapon animations
@@ -123,3 +125,4 @@ Factory for creating weapon entities through registered handlers.
 > **Error Handling:** Always validate handler exists before use
 > **Physics:** Weapon sprites are created as sensors by default
 > **Positioning:** Weapons use owner's position + SWORD.CONFIG.OFFSET
+> **Type Safety:** Only `ENTITY_TYPES.SWORD` is currently supported as WeaponEntityTypes

--- a/docs/client/game/ecs/systems/state/handlers/player/PlayerStateHandler.md
+++ b/docs/client/game/ecs/systems/state/handlers/player/PlayerStateHandler.md
@@ -1,4 +1,4 @@
-# Player State Handler Documentation
+# PlayerStateHandler Documentation
 
 ## Overview
 
@@ -8,17 +8,18 @@ The `PlayerStateHandler` is responsible for managing and transitioning between d
 
 ## Technical Identity
 
-- **Type:** Handler
-- **Domain:** State Management
+- **Type:** Handler  
+- **Domain:** State Management  
 
 ---
 
 ## Responsibilities
 
-- Ensures only valid player entities are processed
-- Determines player mobility state (grounded or airborne)
-- Delegates state resolution to appropriate handlers (`GroundedHandler`/`AirborneHandler`)
-- Maintains separation of concerns between grounded and airborne states
+- Ensures only valid player entities are processed  
+- Determines player mobility state (grounded or airborne)  
+- Delegates state resolution to appropriate handlers (`GroundedHandler`/`AirborneHandler`)  
+- Maintains separation of concerns between grounded and airborne states  
+- Manages attack state expiration and input lockout  
 
 ---
 
@@ -26,28 +27,30 @@ The `PlayerStateHandler` is responsible for managing and transitioning between d
 
 ### Manipulated Components
 
-- **Reads:**
-  - `StateComponent`: Checks current state
-  - `InputComponent`: Evaluates player input
-  - `VelocityComponent`: Indirectly used by `getMobility()` utility
-  - `Phaser.Physics.Matter.Sprite`: Determines mobility state via `getMobility()`
-- **Writes:**
-  - `StateComponent`: Explicitly sets to validated `CharacterState` from handler resolution
+- **Reads:**  
+  - `StateComponent`: Checks current state and ticker  
+  - `InputComponent`: Evaluates player input  
+  - `Phaser.Physics.Matter.Sprite`: Determines mobility state via `getMobility()`  
+- **Writes:**  
+  - `StateComponent`: Updates current state and attack lock status  
 
 ### Configuration Props
 
-- `PlayerStateHandlerUpdateProp` (`*.p.ts`): Contains the entity to be processed
+- `PlayerStateHandlerUpdateProp`: Contains the entity to be processed  
 
 ---
 
 ## Lifecycle & Execution Flow
 
-1. **Initialization:** Creates `GroundedHandler` and `AirborneHandler` instances
-2. **Update Loop:**
-   - Validates entity
-   - Determines mobility state
-   - Delegates to appropriate handler
-3. **Teardown:** N/A
+1. **Initialization:** Creates `GroundedHandler` and `AirborneHandler` instances  
+2. **Update Loop:**  
+   - Validates entity  
+   - Checks active ticker state  
+   - Resets expired attack states  
+   - Updates attack lock status  
+   - Determines effective input  
+   - Delegates to appropriate handler based on mobility  
+3. **Teardown:** N/A  
 
 ---
 
@@ -55,60 +58,93 @@ The `PlayerStateHandler` is responsible for managing and transitioning between d
 
 ### `update({ entity }: PlayerStateHandlerUpdateProp): void`
 
-**Description:** Main update method that processes player state transitions
+**Description:** Main update method that processes player state transitions  
 
-**Flow:**
+**Flow:**  
+1. Validates entity contains required components  
+2. Checks and decrements active ticker if present  
+3. Resets expired attack states  
+4. Updates attack lock status  
+5. Determines effective input (accounting for lockout)  
+6. Determines mobility state  
+7. Delegates to appropriate handler  
 
-1. Validates entity contains required components (input, state, sprite)
-2. Determines mobility state via `getMobility(sprite)` (GROUNDED/AIRBORNE)
-3. Delegates to appropriate handler based on mobility:
-   - `GroundedHandler`: Handles ground-based states (walk/idle/combat)
-   - `AirborneHandler`: Handles air-based states (jump/falling/airborne-attack)
+**Side Effects:**  
+- Modifies `StateComponent.current`  
+- Updates `StateComponent.isAttackSpamming`  
+- Updates `StateComponent.ticker`  
 
-**Implementation Details:**
+### `private resetExpiredAttackState({ state }: { state: StateComponent }): void`
 
-- Uses type guard for safe entity validation
-- Returns early if entity is invalid
-- Handler selection is strictly based on mobility state
-- Delegates actual state resolution to specialized handlers
+**Description:** Resets attack states to IDLE when expired  
 
-**Side Effects:**
+**Flow:**  
+1. Checks if current state is an attack state  
+2. Resets to IDLE if true  
 
-- Modifies `StateComponent.current` based on handler resolution
+**Side Effects:**  
+- Modifies `StateComponent.current`  
 
----
+### `private updateAttackLockState({ state, input }: { state: StateComponent; input: InputComponent }): void`
+
+**Description:** Manages attack input lockout state  
+
+**Flow:**  
+1. Resets lock if no sword input  
+2. Sets lock and ticker if sword input detected  
+
+**Side Effects:**  
+- Modifies `StateComponent.isAttackSpamming`  
+- Modifies `StateComponent.ticker`  
+
+### `private getEffectiveInput({ state, input }: { state: StateComponent; input: InputComponent }): InputComponent`
+
+**Description:** Returns modified input accounting for lockout  
+
+**Flow:**  
+1. Returns input with sword disabled if locked  
+2. Returns original input otherwise  
+
+**Side Effects:** None  
+
+### `private resolvePlayerMobilityState({ state, sprite, input }: { state: StateComponent; sprite: Phaser.Physics.Matter.Sprite; input: InputComponent }): void`
+
+**Description:** Delegates to appropriate mobility handler  
+
+**Flow:**  
+1. Determines mobility via `getMobility()`  
+2. Delegates to `GroundedHandler` or `AirborneHandler`  
+
+**Side Effects:**  
+- Indirectly modifies `StateComponent.current` via handlers  
 
 ### `private isValidPlayer(entity: GlobalEntity): entity is ValidPlayerEntity`
 
-**Description:** Type guard that validates player entity structure
+**Description:** Type guard for valid player entities  
 
-**Flow:**
+**Flow:**  
+1. Checks for required components (`input`, `state`, `sprite`)  
 
-1. Checks entity has all required components:
-   - `input`: Player input configurations
-   - `state`: Current state tracking
-   - `sprite`: Physics body representation
-2. Returns type-predicated boolean for type safety
-
-**Side Effects:**
-
-N/A
+**Side Effects:** None  
 
 ---
 
 ## Dependencies & Relationships
 
-- **Core Dependencies:**
-  - `getMobility()` physics utility
-  - `MOBILITY` and `CHARACTER_STATE` constants
-  - `Phaser.Physics.Matter.Sprite` (Runtime physics body type)
-- **Related Systems:**
-  - `StateSystem`: Receives state updates from this handler
-- **Events Consumed/Emitted:** N/A
+- **Core Dependencies:**  
+  - `CHARACTER_STATE`, `CHARACTER_COMBAT`, `MOBILITY` constants  
+  - `getMobility()`, `isTickerActive()`, `decrementStateTicker()` utilities  
+  - `GroundedHandler`, `AirborneHandler`  
+- **Related Systems:**  
+  - `StateSystem`: Receives state updates from this handler  
+- **Events Consumed/Emitted:** N/A  
 
 ---
 
 ## Maintenance Notes
 
 > [!WARNING]  
-> **Performance:** This handler runs on the `update` loop. Keep mobility checks lightweight.
+> **Performance:** This handler runs on the `update` loop. Keep mobility checks lightweight.  
+
+> [!NOTE]  
+> **State Management:** Attack states automatically expire after `CHARACTER_COMBAT.ATTACK.DURATION_TICKS`  

--- a/docs/client/game/ecs/systems/state/handlers/player/PlayerStateHandler.md
+++ b/docs/client/game/ecs/systems/state/handlers/player/PlayerStateHandler.md
@@ -1,4 +1,4 @@
-# PlayerStateHandler Documentation
+# Player State Handler Documentation
 
 ## Overview
 

--- a/packages/client/src/game/config/constants/character/combat/characterCombat.ts
+++ b/packages/client/src/game/config/constants/character/combat/characterCombat.ts
@@ -1,0 +1,7 @@
+const CHARACTER_COMBAT = {
+  ATTACK: {
+    DURATION_TICKS: 45,
+  },
+} as const;
+
+export { CHARACTER_COMBAT };

--- a/packages/client/src/game/config/constants/character/combat/index.ts
+++ b/packages/client/src/game/config/constants/character/combat/index.ts
@@ -1,0 +1,1 @@
+export * from './characterCombat';

--- a/packages/client/src/game/config/constants/character/index.ts
+++ b/packages/client/src/game/config/constants/character/index.ts
@@ -2,3 +2,4 @@ export * from './name';
 export * from './sprite-model';
 export * from './skins';
 export * from './states';
+export * from './combat';

--- a/packages/client/src/game/config/constants/weapon/weapon.ts
+++ b/packages/client/src/game/config/constants/weapon/weapon.ts
@@ -11,6 +11,7 @@ export const SWORD = {
       BASE: 100,
       MULTIPLIER: 1,
     },
+    DURATION_TICKS: 45,
   },
 } as const;
 

--- a/packages/client/src/game/ecs/components/state/StateComponent.ts
+++ b/packages/client/src/game/ecs/components/state/StateComponent.ts
@@ -1,6 +1,7 @@
 interface StateComponent {
   current: string;
   ticker?: number;
+  isAttackSpamming?: boolean;
 }
 
 export type { StateComponent };

--- a/packages/client/src/game/ecs/components/state/StateComponent.ts
+++ b/packages/client/src/game/ecs/components/state/StateComponent.ts
@@ -1,5 +1,6 @@
 interface StateComponent {
   current: string;
+  ticker?: number;
 }
 
 export type { StateComponent };

--- a/packages/client/src/game/ecs/systems/state/handlers/player/PlayerStateHandler.ts
+++ b/packages/client/src/game/ecs/systems/state/handlers/player/PlayerStateHandler.ts
@@ -1,6 +1,7 @@
-import { MOBILITY } from '@/config/constants';
+import { CHARACTER_COMBAT, CHARACTER_STATE, MOBILITY } from '@/config/constants';
 import { GlobalEntity } from '@/ecs/entities';
 import { getMobility } from '@/utils/physics';
+import { decrementStateTicker, isTickerActive } from '@/utils/state';
 import { GroundedHandler, AirborneHandler } from './helpers';
 
 import { IEntityStateHandler } from '../types.i';
@@ -19,6 +20,23 @@ class PlayerStateHandler implements IEntityStateHandler {
     if (!this.isValidPlayer(entity)) return;
 
     const { state, input, sprite } = entity;
+
+    if (isTickerActive({ state })) {
+      decrementStateTicker({ state });
+      return;
+    }
+
+    if (input.sword) {
+      const isAlreadyAttacking =
+        state.current === CHARACTER_STATE.SHORT_ATTACK_FORWARD ||
+        state.current === CHARACTER_STATE.SHORT_ATTACK_UP ||
+        state.current === CHARACTER_STATE.SHORT_ATTACK_DOWN;
+
+      if (!isAlreadyAttacking) {
+        state.ticker = CHARACTER_COMBAT.ATTACK.DURATION_TICKS;
+      }
+    }
+
     const mobility = getMobility(sprite);
 
     if (mobility === MOBILITY.GROUNDED) {

--- a/packages/client/src/game/ecs/systems/state/handlers/player/PlayerStateHandler.ts
+++ b/packages/client/src/game/ecs/systems/state/handlers/player/PlayerStateHandler.ts
@@ -1,4 +1,5 @@
 import { CHARACTER_COMBAT, CHARACTER_STATE, MOBILITY } from '@/config/constants';
+import { InputComponent, StateComponent } from '@/ecs/components';
 import { GlobalEntity } from '@/ecs/entities';
 import { getMobility } from '@/utils/physics';
 import { decrementStateTicker, isTickerActive } from '@/utils/state';
@@ -26,17 +27,64 @@ class PlayerStateHandler implements IEntityStateHandler {
       return;
     }
 
-    if (input.sword) {
-      const isAlreadyAttacking =
-        state.current === CHARACTER_STATE.SHORT_ATTACK_FORWARD ||
-        state.current === CHARACTER_STATE.SHORT_ATTACK_UP ||
-        state.current === CHARACTER_STATE.SHORT_ATTACK_DOWN;
+    this.resetExpiredAttackState({ state });
+    this.updateAttackLockState({ state, input });
 
-      if (!isAlreadyAttacking) {
-        state.ticker = CHARACTER_COMBAT.ATTACK.DURATION_TICKS;
-      }
+    const effectiveInput = this.getEffectiveInput({ state, input });
+
+    this.resolvePlayerMobilityState({ state, sprite, input: effectiveInput });
+  }
+
+  private resetExpiredAttackState({ state }: { state: StateComponent }): void {
+    const isAttackingState =
+      state.current === CHARACTER_STATE.SHORT_ATTACK_FORWARD ||
+      state.current === CHARACTER_STATE.SHORT_ATTACK_UP ||
+      state.current === CHARACTER_STATE.SHORT_ATTACK_DOWN;
+
+    if (isAttackingState) {
+      state.current = CHARACTER_STATE.IDLE;
+    }
+  }
+
+  private updateAttackLockState({
+    state,
+    input,
+  }: {
+    state: StateComponent;
+    input: InputComponent;
+  }): void {
+    if (!input.sword) {
+      state.isAttackSpamming = false;
     }
 
+    if (input.sword && !state.isAttackSpamming) {
+      state.ticker = CHARACTER_COMBAT.ATTACK.DURATION_TICKS;
+      state.isAttackSpamming = true;
+    }
+  }
+
+  private getEffectiveInput({
+    state,
+    input,
+  }: {
+    state: StateComponent;
+    input: InputComponent;
+  }): InputComponent {
+    if (state.isAttackSpamming && !isTickerActive({ state })) {
+      return { ...input, sword: false };
+    }
+    return input;
+  }
+
+  private resolvePlayerMobilityState({
+    state,
+    sprite,
+    input,
+  }: {
+    state: StateComponent;
+    sprite: Phaser.Physics.Matter.Sprite;
+    input: InputComponent;
+  }): void {
     const mobility = getMobility(sprite);
 
     if (mobility === MOBILITY.GROUNDED) {

--- a/packages/client/src/game/ecs/systems/state/handlers/sword/SwordStateHandler.ts
+++ b/packages/client/src/game/ecs/systems/state/handlers/sword/SwordStateHandler.ts
@@ -1,4 +1,5 @@
 import { ENTITY_TYPES, SWORD, SWORD_STATE } from '@/config/constants';
+import { InputComponent, StateComponent } from '@/ecs/components';
 import { GlobalEntity } from '@/ecs/entities';
 import { decrementStateTicker, isTickerActive } from '@/utils/state';
 import { IEntityStateHandler } from '../types.i';
@@ -15,11 +16,40 @@ class SwordStateHandler implements IEntityStateHandler {
       return;
     }
 
-    if (input.sword) {
-      if (state.current !== SWORD_STATE.SLASHING) {
-        state.current = SWORD_STATE.SLASHING;
-        state.ticker = SWORD.ATTACK.DURATION_TICKS;
-      }
+    this.resetExpiredAttackState({ state });
+    this.updateAttackLockState({ state, input });
+    this.resolveSwordState({ state, input });
+  }
+
+  private resetExpiredAttackState({ state }: { state: StateComponent }): void {
+    if (state.current === SWORD_STATE.SLASHING) {
+      state.current = SWORD_STATE.IDLE;
+    }
+  }
+
+  private updateAttackLockState({
+    state,
+    input,
+  }: {
+    state: StateComponent;
+    input: InputComponent;
+  }): void {
+    if (!input.sword) {
+      state.isAttackSpamming = false;
+    }
+  }
+
+  private resolveSwordState({
+    state,
+    input,
+  }: {
+    state: StateComponent;
+    input: InputComponent;
+  }): void {
+    if (input.sword && !state.isAttackSpamming) {
+      state.current = SWORD_STATE.SLASHING;
+      state.ticker = SWORD.ATTACK.DURATION_TICKS;
+      state.isAttackSpamming = true;
     } else {
       state.current = SWORD_STATE.IDLE;
     }

--- a/packages/client/src/game/ecs/systems/state/handlers/sword/SwordStateHandler.ts
+++ b/packages/client/src/game/ecs/systems/state/handlers/sword/SwordStateHandler.ts
@@ -1,5 +1,6 @@
-import { ENTITY_TYPES, SWORD_STATE } from '@/config/constants';
+import { ENTITY_TYPES, SWORD, SWORD_STATE } from '@/config/constants';
 import { GlobalEntity } from '@/ecs/entities';
+import { decrementStateTicker, isTickerActive } from '@/utils/state';
 import { IEntityStateHandler } from '../types.i';
 import { SwordStateHandlerUpdateProp, ValidSwordEntity } from './types.p';
 
@@ -9,8 +10,16 @@ class SwordStateHandler implements IEntityStateHandler {
 
     const { state, input } = entity;
 
+    if (isTickerActive({ state })) {
+      decrementStateTicker({ state });
+      return;
+    }
+
     if (input.sword) {
-      state.current = SWORD_STATE.SLASHING;
+      if (state.current !== SWORD_STATE.SLASHING) {
+        state.current = SWORD_STATE.SLASHING;
+        state.ticker = SWORD.ATTACK.DURATION_TICKS;
+      }
     } else {
       state.current = SWORD_STATE.IDLE;
     }

--- a/packages/client/src/game/utils/state/decrementStateTicker.ts
+++ b/packages/client/src/game/utils/state/decrementStateTicker.ts
@@ -1,0 +1,12 @@
+import { DecrementStateTickerProp } from './types.p';
+
+function decrementStateTicker({ state }: DecrementStateTickerProp): void {
+  if (state.ticker !== undefined && state.ticker > 0) {
+    state.ticker -= 1;
+    if (state.ticker <= 0) {
+      state.ticker = undefined;
+    }
+  }
+}
+
+export { decrementStateTicker };

--- a/packages/client/src/game/utils/state/index.ts
+++ b/packages/client/src/game/utils/state/index.ts
@@ -1,0 +1,3 @@
+export * from './isTickerActive';
+export * from './decrementStateTicker';
+export * from './types.p';

--- a/packages/client/src/game/utils/state/isTickerActive.ts
+++ b/packages/client/src/game/utils/state/isTickerActive.ts
@@ -1,0 +1,7 @@
+import { IsTickerActiveProp } from './types.p';
+
+function isTickerActive({ state }: IsTickerActiveProp): boolean {
+  return state.ticker !== undefined && state.ticker > 0;
+}
+
+export { isTickerActive };

--- a/packages/client/src/game/utils/state/types.p.ts
+++ b/packages/client/src/game/utils/state/types.p.ts
@@ -1,0 +1,11 @@
+import { StateComponent } from '@/ecs/components';
+
+type IsTickerActiveProp = {
+  state: StateComponent;
+};
+
+type DecrementStateTickerProp = {
+  state: StateComponent;
+};
+
+export type { IsTickerActiveProp, DecrementStateTickerProp };


### PR DESCRIPTION
## Information

#### Describe What Was Done

- Create `DURATION_TICKS` constant to control the animation's duration (for now it's being used only for attack animations). This variable ensures that both player and sword attack animation play for the same amount of time.
- Create `isAttackSpamming` state to save when the player is holding to attack button so it can be properly addressed.
- Prevents the player to attack spam by holding the attack button. This forces the player to be strategic and precise while playing. Two core principles of the game.
- Refactor state handlers by extracting the logic into multiple methods to preserve the Single Responsibility 

---

#### Detailed Summary (AI Generated)


<details>
	<summary>
🤖| Summary	</summary>
<br />

<!-- AI-SUMMARY-START -->

**What was done**
Fixed an input-lock issue where holding down the attack button caused both the player character and the sword to remain indefinitely trapped in their attack animations.
Added an `isAttackSpamming` flag to `StateComponent` to track across frames whether the attack key is being continuously held down after an attack completes.
Refactored `PlayerStateHandler` and `SwordStateHandler` to delegate responsibilities to dedicated, single-responsibility helper methods utilizing object destructuring for parameter passing.
Implemented automatic state cleanup (`resetExpiredAttackState`) to transition entities back to IDLE / mobility states once the attack ticker expires.
Created an input masking layer (`getEffectiveInput`) to prevent attack re-triggering and allow normal movement while the attack key remains held.

**Why it was done**
Previously, when the attack duration ticker expired while the attack button was still held down, neither handler reset the current state from attack (SHORT_ATTACK_* / SLASHING) back to initial/movement states.
Because input.sword remained true continuously, state resolution kept forcing the entity back into the attack state without setting a new duration ticker, freezing both character and weapon animations.
The new design guarantees that attack animations execute for their full duration, gracefully return entities to their initial state, and require the player to release and press the attack button again to initiate subsequent attacks.

<!-- AI-SUMMARY-END -->

</details>


---


#### Evidence

<details>
	<summary>
⏪️ | Before - With attack spamming
	</summary>



https://github.com/user-attachments/assets/22227a69-f9c5-4bd7-8ebe-aef37022e7f6






</details>
<details>
	<summary>
⏩ | After - No attack spamming
	</summary>


https://github.com/user-attachments/assets/2283a3cf-2bd1-4cad-84de-841eb14af369






</details>

---

#### Rollback Plan

Revert from the branch.


---

↗️ | **[Click to See The Preview](https://vulpy-labs.github.io/slash-out/preview/pr-87)**