### PR TITLE
081 | Combat - Part 6: Update sword positioning when attacking

### DIFF
--- a/docs/client/game/builders/weapon/WeaponBuilder.md
+++ b/docs/client/game/builders/weapon/WeaponBuilder.md
@@ -8,7 +8,7 @@ Factory for creating weapon entities through registered handlers.
 
 ## Technical Identity
 
-- **Type:** Builder  
+- **Type:** Entity Builder  
 - **Domain:** Weapon Construction
 
 ---
@@ -16,6 +16,7 @@ Factory for creating weapon entities through registered handlers.
 ## Responsibilities
 
 - Manages weapon handler registry
+- Maintains handler registry lifecycle
 - Delegates loading to handlers
 - Delegates building to handlers
 - Notifies EntityManager of new entities
@@ -31,6 +32,7 @@ Factory for creating weapon entities through registered handlers.
 - **Creates:**
   - `GlobalEntity` via handlers
   - Weapon sprites with Matter.js physics
+  - Weapon state components
 
 ### Constants Used
 
@@ -62,6 +64,9 @@ Factory for creating weapon entities through registered handlers.
    - Delegates to handler's build()
    - Throws error if handler not found: `No weapon builder handler found for entity type: ${entityType}`
    - Invokes onEntityCreated callback with built entity
+4. **Handler Management:**
+   - Maintains handler instances in memory
+   - Ensures handlers are properly initialized
 
 ---
 
@@ -91,7 +96,7 @@ Factory for creating weapon entities through registered handlers.
 
 ### `build({ x, y, ownerEntityId, entityType })`
 
-**Description:** Creates weapon entity via registered handler
+**Description:** Creates weapon entity via registered handler and initializes its components
 
 **Flow:**
 - Gets handler by type from map
@@ -111,6 +116,7 @@ Factory for creating weapon entities through registered handlers.
   - `IWeaponHandler` interface (load/build methods)
   - `SwordWeaponHandler` implementation
   - `GlobalEntity` type
+  - `WeaponBuilderProp` and `WeaponBuilderBuildProp` types
 - **Related Systems:**
   - `EntityManager`: Receives created entities
   - `AnimationSystem`: Handles weapon animations
@@ -126,3 +132,4 @@ Factory for creating weapon entities through registered handlers.
 > **Physics:** Weapon sprites are created as sensors by default
 > **Positioning:** Weapons use owner's position + SWORD.CONFIG.OFFSET
 > **Type Safety:** Only `ENTITY_TYPES.SWORD` is currently supported as WeaponEntityTypes
+> **Memory Management:** Handlers are kept in memory indefinitely. Consider cleanup strategy if adding many handlers

--- a/docs/client/game/builders/weapon/handlers/sword/SwordWeaponHandler.md
+++ b/docs/client/game/builders/weapon/handlers/sword/SwordWeaponHandler.md
@@ -38,6 +38,7 @@ Factory handler responsible for creating and configuring sword weapon entities. 
 
 - `SWORD.CONFIG`: Defines sword dimensions and origin
 - `DEPTH.ENTITIES`: Sets initial sprite depth
+- `SWORD_STATE.IDLE`: Initial sword state
 
 ---
 
@@ -66,9 +67,15 @@ Factory handler responsible for creating and configuring sword weapon entities. 
 **Side Effects:**
 - Adds assets to Phaser loader
 
-### `build({ scene, ownerEntityId }): GlobalEntity`
+### `build({ scene, x, y, ownerEntityId }): GlobalEntity`
 
 **Description:** Constructs sword entity
+
+**Parameters:**
+- `scene: Phaser.Scene`: Phaser scene instance
+- `x: number`: Initial X coordinate
+- `y: number`: Initial Y coordinate
+- `ownerEntityId: string`: Entity ID of the weapon owner
 
 **Flow:**
 - Creates Matter sprite
@@ -87,6 +94,9 @@ Factory handler responsible for creating and configuring sword weapon entities. 
 - **Core Dependencies:**
   - `Phaser.Physics.Matter.Sprite`
   - `SWORD.CONFIG` constants
+  - `ENTITY_TYPES.SWORD`
+  - `GlobalEntity` type
+  - `defaultInput`, `defaultKeymap`, `defaultSwordAnimation` factories
 - **Related Systems:**
   - `EntityManager`: Registers created entities
   - `WeaponSystem`: Manages weapon behavior
@@ -96,5 +106,5 @@ Factory handler responsible for creating and configuring sword weapon entities. 
 ## Maintenance Notes
 
 > [!WARNING]  
-> **Asset Loading:** Always check `textures.exists()` before loading
-> **Physics:** Sensor bodies don't trigger collisions
+> **Asset Loading:** Always check `textures.exists()` before loading  
+> **Physics:** Sensor bodies do not produce physical collision responses, while Matter.js still detects eligible overlaps and emits collision events

--- a/docs/client/game/builders/weapon/handlers/sword/SwordWeaponHandler.md
+++ b/docs/client/game/builders/weapon/handlers/sword/SwordWeaponHandler.md
@@ -1,0 +1,100 @@
+# SwordWeaponHandler Documentation
+
+## Overview
+
+Factory handler responsible for creating and configuring sword weapon entities. Loads sword assets and constructs sword entities with proper physics and rendering properties.
+
+---
+
+## Technical Identity
+
+- **Type:** Builder Handler  
+- **Domain:** Weapon/Entity Creation  
+
+---
+
+## Responsibilities
+
+- Preloads sword sprite assets
+- Constructs sword entities with Matter.js physics
+- Configures sword sprite properties
+- Sets up default components for sword entities
+
+---
+
+## Data Schema
+
+### Manipulated Components
+
+- **Reads:** N/A (Builder pattern)
+- **Writes:**
+  - `Sprite`: Creates and configures Matter sprite
+  - `StateComponent`: Initializes sword state
+  - `InputComponent`: Sets default input
+  - `KeymapComponent`: Configures key bindings
+  - `AnimationComponent`: Sets default animations
+
+### Configuration Props
+
+- `SWORD.CONFIG`: Defines sword dimensions and origin
+- `DEPTH.ENTITIES`: Sets initial sprite depth
+
+---
+
+## Lifecycle & Execution Flow
+
+1. **Loading:**
+   - Checks and loads sword sprite assets
+2. **Building:**
+   - Creates Matter.js sprite
+   - Configures physics body
+   - Sets initial properties
+   - Returns complete entity
+
+---
+
+## Methods
+
+### `load({ scene }: { scene: Phaser.Scene }): void`
+
+**Description:** Preloads sword sprite assets
+
+**Flow:**
+- Checks if textures exist
+- Loads missing sword sprites
+
+**Side Effects:**
+- Adds assets to Phaser loader
+
+### `build({ scene, ownerEntityId }): GlobalEntity`
+
+**Description:** Constructs sword entity
+
+**Flow:**
+- Creates Matter sprite
+- Configures display and physics
+- Sets initial components
+- Returns complete entity
+
+**Side Effects:**
+- Creates new entity instance
+- Initializes physics body
+
+---
+
+## Dependencies & Relationships
+
+- **Core Dependencies:**
+  - `Phaser.Physics.Matter.Sprite`
+  - `SWORD.CONFIG` constants
+- **Related Systems:**
+  - `EntityManager`: Registers created entities
+  - `WeaponSystem`: Manages weapon behavior
+
+---
+
+## Maintenance Notes
+
+> [!WARNING]  
+> **Asset Loading:** Always check `textures.exists()` before loading
+> **Physics:** Sensor bodies don't trigger collisions

--- a/docs/client/game/ecs/entities/base/BaseEntity.md
+++ b/docs/client/game/ecs/entities/base/BaseEntity.md
@@ -19,6 +19,7 @@ The `BaseEntity` defines the fundamental properties that all entities in the ECS
 
 - **entityId**: Unique string identifier for each entity instance
 - **entityType**: Classification type from `EntityTypes` constants
+- **ownerEntityId** (optional): Reference to owning entity
 - **sprite** (optional): Reference to the Matter.js physics sprite
 
 ---
@@ -28,6 +29,7 @@ The `BaseEntity` defines the fundamental properties that all entities in the ECS
 - **Core Dependencies:**
   - `EntityTypes` constant
   - `Phaser.Physics.Matter.Sprite` from Phaser
+  - `Phaser.Physics.Matter` namespace
 
 ---
 

--- a/docs/client/game/ecs/systems/weapon/WeaponSystem.md
+++ b/docs/client/game/ecs/systems/weapon/WeaponSystem.md
@@ -1,0 +1,89 @@
+# WeaponSystem Documentation
+
+## Overview
+
+Orchestrates weapon behavior by delegating to type-specific handlers. Maintains a map of weapon handlers and routes updates to the appropriate handler based on entity type.
+
+---
+
+## Technical Identity
+
+- **Type:** System  
+- **Domain:** Weapon Management  
+
+---
+
+## Responsibilities
+
+- Maintains weapon handler registry
+- Routes entity updates to proper handlers
+- Ensures type-safe weapon processing
+
+---
+
+## Data Schema
+
+### Manipulated Components
+
+- **Reads:**
+  - `entityType`: Determines handler selection
+- **Writes:** N/A (Delegates to handlers)
+
+### Configuration Props
+
+- `handlers`: Map of weapon type to handler instances
+
+---
+
+## Lifecycle & Execution Flow
+
+1. **Initialization:**
+   - Registers default weapon handlers
+2. **Update Loop:**
+   - Routes each entity to its handler
+   - Delegates update logic
+
+---
+
+## Methods
+
+### `constructor()`
+
+**Description:** Initializes weapon system
+
+**Flow:**
+- Creates handlers map
+- Registers default handlers
+
+**Side Effects:**
+- Initializes handler instances
+
+### `update({ entities }: WeaponSystemUpdateProp): void`
+
+**Description:** Main update method
+
+**Flow:**
+- Iterates through entities
+- Finds matching handler
+- Delegates update
+
+**Side Effects:**
+- Invokes handler updates
+
+---
+
+## Dependencies & Relationships
+
+- **Core Dependencies:**
+  - `IWeaponSystemHandler` interface
+  - `EntityTypes` constants
+- **Related Systems:**
+  - All weapon handlers (e.g., `SwordWeaponSystemHandler`)
+  - `StateSystem`: Determines weapon states
+
+---
+
+## Maintenance Notes
+
+> [!NOTE]  
+> **Extensibility:** Add new weapon types by registering additional handlers

--- a/docs/client/game/ecs/systems/weapon/WeaponSystem.md
+++ b/docs/client/game/ecs/systems/weapon/WeaponSystem.md
@@ -32,6 +32,7 @@ Orchestrates weapon behavior by delegating to type-specific handlers. Maintains 
 ### Configuration Props
 
 - `handlers`: Map of weapon type to handler instances
+- `WeaponSystemUpdateProp`: Update method parameter type
 
 ---
 
@@ -77,8 +78,9 @@ Orchestrates weapon behavior by delegating to type-specific handlers. Maintains 
 - **Core Dependencies:**
   - `IWeaponSystemHandler` interface
   - `EntityTypes` constants
+  - `ENTITY_TYPES` enum
 - **Related Systems:**
-  - All weapon handlers (e.g., `SwordWeaponSystemHandler`)
+  - `SwordWeaponSystemHandler`: Handles sword weapon logic
   - `StateSystem`: Determines weapon states
 
 ---

--- a/docs/client/game/ecs/systems/weapon/handlers/sword/SwordWeaponSystemHandler.md
+++ b/docs/client/game/ecs/systems/weapon/handlers/sword/SwordWeaponSystemHandler.md
@@ -1,4 +1,4 @@
-# SwordWeaponSystemHandler Documentation
+# Sword Weapon System Handler Documentation
 
 ## Overview
 

--- a/docs/client/game/ecs/systems/weapon/handlers/sword/SwordWeaponSystemHandler.md
+++ b/docs/client/game/ecs/systems/weapon/handlers/sword/SwordWeaponSystemHandler.md
@@ -30,6 +30,7 @@ Handles the visual representation and positioning of sword weapons during combat
   - `StateComponent`: Checks current sword state (SLASHING/IDLE)
   - `InputComponent`: Determines attack direction (up/down)
   - `AnimationComponent`: Syncs flip state with character
+  - `ownerEntityId`: Used to find owning character entity
 - **Writes:**
   - Sprite properties: Updates position, visibility, depth, angle
   - `AnimationComponent`: Updates flipX state
@@ -37,6 +38,8 @@ Handles the visual representation and positioning of sword weapons during combat
 ### Configuration Props
 
 - `SWORD.CONFIG.OFFSET`: Determines sword positioning offset from character
+- `SWORD.CONFIG.WIDTH`: Defines sword physics body width
+- `SWORD.CONFIG.HEIGHT`: Defines sword physics body height
 - `DEPTH.ENTITIES`: Used for proper z-index layering
 
 ---
@@ -132,6 +135,8 @@ Handles the visual representation and positioning of sword weapons during combat
   - Phaser.Physics.Matter.Sprite
   - SWORD_STATE constants
   - CHARACTER_STATE constants
+  - ENTITY_TYPES.SWORD
+  - GlobalEntity type
 - **Related Systems:**
   - SwordStateHandler: Determines sword state
   - AnimationSystem: Handles sprite animations

--- a/docs/client/game/ecs/systems/weapon/handlers/sword/SwordWeaponSystemHandler.md
+++ b/docs/client/game/ecs/systems/weapon/handlers/sword/SwordWeaponSystemHandler.md
@@ -1,0 +1,148 @@
+# SwordWeaponSystemHandler Documentation
+
+## Overview
+
+Handles the visual representation and positioning of sword weapons during combat. Manages sword visibility, depth, and positioning relative to the character during different attack states.
+
+---
+
+## Technical Identity
+
+- **Type:** System Handler  
+- **Domain:** Weapon/Combat  
+
+---
+
+## Responsibilities
+
+- Controls sword visibility based on attack state
+- Positions sword sprite relative to character during attacks
+- Manages sword depth rendering
+- Handles sword angle/rotation during different attack directions
+
+---
+
+## Data Schema
+
+### Manipulated Components
+
+- **Reads:**
+  - `StateComponent`: Checks current sword state (SLASHING/IDLE)
+  - `InputComponent`: Determines attack direction (up/down)
+  - `AnimationComponent`: Syncs flip state with character
+- **Writes:**
+  - Sprite properties: Updates position, visibility, depth, angle
+  - `AnimationComponent`: Updates flipX state
+
+### Configuration Props
+
+- `SWORD.CONFIG.OFFSET`: Determines sword positioning offset from character
+- `DEPTH.ENTITIES`: Used for proper z-index layering
+
+---
+
+## Lifecycle & Execution Flow
+
+1. **Initialization:** Creates transform target object for positioning calculations
+2. **Update Loop:** 
+   - Checks sword state
+   - Shows/positions or hides sword based on state
+   - Calculates proper offsets and angles
+3. **Teardown:** N/A (stateless handler)
+
+---
+
+## Methods
+
+### `update({ entity, entities }: SwordWeaponSystemHandlerUpdateProp): void`
+
+**Description:** Main update method called each frame to handle sword state
+
+**Flow:**
+- Validates entity is a sword
+- Routes to show/hide logic based on state
+- Delegates positioning calculations
+
+**Side Effects:**
+- Modifies sprite visibility and position
+- Updates animation flip state
+
+### `private showAndPositionSword({ entity, entities }): void`
+
+**Description:** Handles visible sword state
+
+**Flow:**
+- Makes sprite visible
+- Sets proper depth
+- Finds owner entity
+- Calculates position relative to owner
+
+**Side Effects:**
+- Modifies sprite properties
+
+### `private updateTransform({ sword, owner }): void`
+
+**Description:** Calculates and applies sword positioning
+
+**Flow:**
+- Checks owner flip state
+- Calculates offsets based on attack direction
+- Applies position, angle and flip to sprite
+
+**Side Effects:**
+- Updates sprite transform properties
+
+### `private populateOffsetAndAngle({ ownerState, ownerInput, isFlipped }): void`
+
+**Description:** Determines sword positioning offsets
+
+**Flow:**
+- Checks for up/down attack inputs
+- Calculates appropriate offsets and angles
+- Stores results in transform target
+
+**Side Effects:**
+- Updates internal transform target object
+
+### `private hideSword({ entity }): void`
+
+**Description:** Handles hidden sword state
+
+**Flow:**
+- Hides sprite
+- Resets depth and angle
+- Moves offscreen
+
+**Side Effects:**
+- Modifies sprite properties
+
+### `private isValidSword(entity): boolean`
+
+**Description:** Type guard for sword entities
+
+**Flow:**
+- Checks for required components
+- Verifies entity type
+
+---
+
+## Dependencies & Relationships
+
+- **Core Dependencies:** 
+  - Phaser.Physics.Matter.Sprite
+  - SWORD_STATE constants
+  - CHARACTER_STATE constants
+- **Related Systems:**
+  - SwordStateHandler: Determines sword state
+  - AnimationSystem: Handles sprite animations
+- **Events Consumed/Emitted:** N/A
+
+---
+
+## Maintenance Notes
+
+> [!WARNING]  
+> **Performance:** Runs in update loop. Avoid adding allocations - transform target is reused.
+
+> [!NOTE]  
+> **Positioning:** Sword offset is relative to character sprite center point. Adjust SWORD.CONFIG.OFFSET for different weapon lengths.

--- a/docs/client/game/scenes/game/match/MatchScene.md
+++ b/docs/client/game/scenes/game/match/MatchScene.md
@@ -110,11 +110,15 @@ The `MatchScene` is the core gameplay scene that initializes and manages the ECS
 - **Core Dependencies:**
   - `Phaser.Scene`
   - `EntityManager`
+  - `GlobalEntityMap` type
   - ECS Systems
 - **Related Systems:**
   - All ECS systems in defined order
+  - `WeaponSystem`: Manages weapon behaviors
 - **Builders:**
   - `MapBuilder`: Constructs game world
+- **Managers:**
+  - `EntityManager`: Handles entity lifecycle
 
 ---
 

--- a/docs/client/game/scenes/game/match/MatchScene.md
+++ b/docs/client/game/scenes/game/match/MatchScene.md
@@ -101,7 +101,8 @@ The `MatchScene` is the core gameplay scene that initializes and manages the ECS
 2. Handles movement
 3. Updates velocities
 4. Manages states
-5. Animates entities
+5. Updates weapons
+6. Animates entities
 
 ---
 

--- a/docs/client/game/utils/factories/ecs/components/movement/defaultMovement.md
+++ b/docs/client/game/utils/factories/ecs/components/movement/defaultMovement.md
@@ -8,7 +8,7 @@ The `defaultMovement` factory creates a `MovementComponent` with default intent 
 
 ## Technical Identity
 
-- **Type:** Factory
+- **Type:** Component Factory
 - **Domain:** Movement
 
 ---
@@ -16,6 +16,7 @@ The `defaultMovement` factory creates a `MovementComponent` with default intent 
 ## Responsibilities
 
 - Builds a normalized `MovementComponent` payload for new entities
+- Ensures consistent movement component initialization
 - Initializes movement intent with neutral values
 - Resolves air and ground movement configuration from `MOVEMENT_MAPPING`
 
@@ -46,7 +47,7 @@ The `defaultMovement` factory creates a `MovementComponent` with default intent 
 ## Lifecycle & Execution Flow
 
 1. **Initialization:** N/A (Stateless)
-2. **Update Loop:** Called during entity/component assembly
+2. **Execution:** Called during entity/component assembly to initialize movement parameters
 3. **Teardown:** N/A (Stateless)
 
 ---
@@ -59,25 +60,19 @@ The `defaultMovement` factory creates a `MovementComponent` with default intent 
 
 **Flow:**
 
+- Validates entityType against MOVEMENT_MAPPING keys
 - Reads the movement profile from `MOVEMENT_MAPPING[entityType]`
-- Initializes `intent` with:
-  - `moveX: 0`
-  - `moveY: 0`
-- Maps air movement values:
-  - `speed` from `MOVEMENT_MAPPING[entityType].AIR.SPEED`
-  - `friction` from `MOVEMENT_MAPPING[entityType].AIR.FRICTION`
-- Maps ground movement values:
-  - `speed` from `MOVEMENT_MAPPING[entityType].GROUND.SPEED`
-  - `friction` from `MOVEMENT_MAPPING[entityType].GROUND.FRICTION`
+- Initializes `intent` with neutral values
+- Maps air and ground movement values from configuration
 
 ---
 
 ## Dependencies & Relationships
 
 - **Core Dependencies:**
-  - `MOVEMENT_MAPPING`
-  - `MovementComponent`
-  - `DefaultMovementProp`
+  - `MOVEMENT_MAPPING` configuration
+  - `MovementComponent` interface
+  - `DefaultMovementProp` type
 - **Related Systems:**
   - `MovementSystem`: consumes movement intent and movement parameters
 - **Events Consumed/Emitted:** N/A
@@ -90,3 +85,4 @@ The `defaultMovement` factory creates a `MovementComponent` with default intent 
 > **Consistency:** Keep `MOVEMENT_MAPPING` synchronized with valid `EntityTypes` to avoid undefined movement profiles.
 >
 > **Type Safety:** Ensure `entityType` parameter matches the keys in `MOVEMENT_MAPPING` to prevent runtime errors.
+> **Configuration:** Movement parameters are centralized in MOVEMENT_MAPPING for easy tuning

--- a/docs/client/game/utils/factories/ecs/components/movement/defaultMovement.md
+++ b/docs/client/game/utils/factories/ecs/components/movement/defaultMovement.md
@@ -60,8 +60,7 @@ The `defaultMovement` factory creates a `MovementComponent` with default intent 
 
 **Flow:**
 
-- Validates entityType against MOVEMENT_MAPPING keys
-- Reads the movement profile from `MOVEMENT_MAPPING[entityType]`
+- Performs typed `MOVEMENT_MAPPING[entityType]` lookup
 - Initializes `intent` with neutral values
 - Maps air and ground movement values from configuration
 

--- a/packages/client/src/game/builders/weapon/handlers/sword/SwordWeaponHandler.ts
+++ b/packages/client/src/game/builders/weapon/handlers/sword/SwordWeaponHandler.ts
@@ -46,6 +46,7 @@ export class SwordWeaponHandler implements IWeaponHandler {
 
     return {
       entityId: `sword_${ownerEntityId}`,
+      ownerEntityId,
       entityType: ENTITY_TYPES.SWORD,
       sprite,
       state: { current: SWORD_STATE.IDLE },

--- a/packages/client/src/game/builders/weapon/handlers/sword/SwordWeaponHandler.ts
+++ b/packages/client/src/game/builders/weapon/handlers/sword/SwordWeaponHandler.ts
@@ -20,8 +20,6 @@ export class SwordWeaponHandler implements IWeaponHandler {
 
   build({
     scene,
-    x,
-    y,
     ownerEntityId,
   }: {
     scene: Phaser.Scene;
@@ -29,7 +27,7 @@ export class SwordWeaponHandler implements IWeaponHandler {
     y: number;
     ownerEntityId: string;
   }): GlobalEntity {
-    const sprite = scene.matter.add.sprite(x, y, 'spr_sword_0');
+    const sprite = scene.matter.add.sprite(-9999, -9999, 'spr_sword_0');
 
     sprite.setDisplaySize(SWORD.CONFIG.WIDTH, SWORD.CONFIG.HEIGHT);
     sprite.setOrigin(SWORD.CONFIG.ORIGIN_X, SWORD.CONFIG.ORIGIN_Y);
@@ -41,6 +39,7 @@ export class SwordWeaponHandler implements IWeaponHandler {
 
     sprite.setSensor(true);
     sprite.setIgnoreGravity(true);
+    sprite.setVisible(false);
     sprite.setDepth(DEPTH.ENTITIES);
 
     const playerRef = ownerEntityId.includes('02') ? '02' : '01';

--- a/packages/client/src/game/ecs/entities/base/BaseEntity.ts
+++ b/packages/client/src/game/ecs/entities/base/BaseEntity.ts
@@ -3,6 +3,7 @@ import type { EntityTypes } from '@/config/constants';
 interface BaseEntity {
   entityId: string;
   entityType: EntityTypes;
+  ownerEntityId?: string;
   sprite?: Phaser.Physics.Matter.Sprite;
 }
 

--- a/packages/client/src/game/ecs/systems/index.ts
+++ b/packages/client/src/game/ecs/systems/index.ts
@@ -4,3 +4,4 @@ export * from './movement';
 export * from './velocity';
 export * from './animation';
 export * from './state';
+export * from './weapon';

--- a/packages/client/src/game/ecs/systems/weapon/WeaponSystem.ts
+++ b/packages/client/src/game/ecs/systems/weapon/WeaponSystem.ts
@@ -1,0 +1,21 @@
+import { ENTITY_TYPES, EntityTypes } from '@/config/constants';
+import { IWeaponSystemHandler, SwordWeaponSystemHandler } from './handlers';
+import { WeaponSystemUpdateProp } from './types.p';
+
+class WeaponSystem {
+  private handlers: Map<EntityTypes, IWeaponSystemHandler>;
+
+  constructor() {
+    this.handlers = new Map<EntityTypes, IWeaponSystemHandler>([
+      [ENTITY_TYPES.SWORD, new SwordWeaponSystemHandler()],
+    ]);
+  }
+
+  update({ entities }: WeaponSystemUpdateProp): void {
+    entities.forEach(entity => {
+      this.handlers.get(entity.entityType)?.update({ entity, entities });
+    });
+  }
+}
+
+export { WeaponSystem };

--- a/packages/client/src/game/ecs/systems/weapon/handlers/index.ts
+++ b/packages/client/src/game/ecs/systems/weapon/handlers/index.ts
@@ -1,0 +1,2 @@
+export * from './types.i';
+export * from './sword';

--- a/packages/client/src/game/ecs/systems/weapon/handlers/sword/SwordWeaponSystemHandler.ts
+++ b/packages/client/src/game/ecs/systems/weapon/handlers/sword/SwordWeaponSystemHandler.ts
@@ -4,6 +4,8 @@ import { IWeaponSystemHandler } from '../types.i';
 import { SwordWeaponSystemHandlerUpdateProp, ValidSwordWeaponEntity } from './types.p';
 
 class SwordWeaponSystemHandler implements IWeaponSystemHandler {
+  private readonly transformTarget = { offsetX: 0, offsetY: 0, angle: 0 };
+
   update({ entity, entities }: SwordWeaponSystemHandlerUpdateProp): void {
     if (!this.isValidSword(entity)) return;
 
@@ -28,7 +30,9 @@ class SwordWeaponSystemHandler implements IWeaponSystemHandler {
 
     if (!entities) return;
 
-    const ownerId = entity.entityId.replace('sword_', '');
+    const ownerId = entity.ownerEntityId;
+    if (!ownerId) return;
+
     const owner = entities.get(ownerId);
 
     if (owner?.sprite) {
@@ -46,22 +50,25 @@ class SwordWeaponSystemHandler implements IWeaponSystemHandler {
     if (!owner.sprite) return;
 
     const isFlipped = owner.animation?.flipX ?? owner.sprite.flipX;
-    const { offsetX, offsetY, angle } = this.calculateOffsetAndAngle({
+    this.populateOffsetAndAngle({
       ownerState: owner.state?.current,
       ownerInput: owner.input,
       isFlipped,
     });
 
-    sword.sprite.setPosition(owner.sprite.x + offsetX, owner.sprite.y + offsetY);
+    sword.sprite.setPosition(
+      owner.sprite.x + this.transformTarget.offsetX,
+      owner.sprite.y + this.transformTarget.offsetY
+    );
     sword.sprite.setFlipX(isFlipped);
-    sword.sprite.setAngle(angle);
+    sword.sprite.setAngle(this.transformTarget.angle);
 
     if (sword.animation) {
       sword.animation.flipX = isFlipped;
     }
   }
 
-  private calculateOffsetAndAngle({
+  private populateOffsetAndAngle({
     ownerState,
     ownerInput,
     isFlipped,
@@ -69,31 +76,27 @@ class SwordWeaponSystemHandler implements IWeaponSystemHandler {
     ownerState?: string;
     ownerInput?: GlobalEntity['input'];
     isFlipped: boolean;
-  }): { offsetX: number; offsetY: number; angle: number } {
+  }): void {
     const isUp = ownerState === CHARACTER_STATE.SHORT_ATTACK_UP || !!ownerInput?.up;
     const isDown = ownerState === CHARACTER_STATE.SHORT_ATTACK_DOWN || !!ownerInput?.down;
 
     if (isUp) {
-      return {
-        offsetX: 0,
-        offsetY: -SWORD.CONFIG.OFFSET,
-        angle: isFlipped ? 90 : -90,
-      };
+      this.transformTarget.offsetX = 0;
+      this.transformTarget.offsetY = -SWORD.CONFIG.OFFSET;
+      this.transformTarget.angle = isFlipped ? 90 : -90;
+      return;
     }
 
     if (isDown) {
-      return {
-        offsetX: 0,
-        offsetY: SWORD.CONFIG.OFFSET,
-        angle: isFlipped ? -90 : 90,
-      };
+      this.transformTarget.offsetX = 0;
+      this.transformTarget.offsetY = SWORD.CONFIG.OFFSET;
+      this.transformTarget.angle = isFlipped ? -90 : 90;
+      return;
     }
 
-    return {
-      offsetX: isFlipped ? -SWORD.CONFIG.OFFSET : SWORD.CONFIG.OFFSET,
-      offsetY: 0,
-      angle: 0,
-    };
+    this.transformTarget.offsetX = isFlipped ? -SWORD.CONFIG.OFFSET : SWORD.CONFIG.OFFSET;
+    this.transformTarget.offsetY = 0;
+    this.transformTarget.angle = 0;
   }
 
   private hideSword({ entity }: { entity: ValidSwordWeaponEntity }): void {

--- a/packages/client/src/game/ecs/systems/weapon/handlers/sword/SwordWeaponSystemHandler.ts
+++ b/packages/client/src/game/ecs/systems/weapon/handlers/sword/SwordWeaponSystemHandler.ts
@@ -23,21 +23,28 @@ class SwordWeaponSystemHandler implements IWeaponSystemHandler {
     entity: ValidSwordWeaponEntity;
     entities?: SwordWeaponSystemHandlerUpdateProp['entities'];
   }): void {
-    const { sprite } = entity;
-
-    sprite.setVisible(true);
-    sprite.setDepth(DEPTH.ENTITIES + 1);
-
-    if (!entities) return;
+    if (!entities) {
+      this.hideSword({ entity });
+      return;
+    }
 
     const ownerId = entity.ownerEntityId;
-    if (!ownerId) return;
+    if (!ownerId) {
+      this.hideSword({ entity });
+      return;
+    }
 
     const owner = entities.get(ownerId);
-
-    if (owner?.sprite) {
-      this.updateTransform({ sword: entity, owner });
+    if (!owner?.sprite) {
+      this.hideSword({ entity });
+      return;
     }
+
+    this.updateTransform({ sword: entity, owner });
+
+    const { sprite } = entity;
+    sprite.setVisible(true);
+    sprite.setDepth(DEPTH.ENTITIES + 1);
   }
 
   private updateTransform({

--- a/packages/client/src/game/ecs/systems/weapon/handlers/sword/SwordWeaponSystemHandler.ts
+++ b/packages/client/src/game/ecs/systems/weapon/handlers/sword/SwordWeaponSystemHandler.ts
@@ -1,0 +1,113 @@
+import { CHARACTER_STATE, DEPTH, ENTITY_TYPES, SWORD, SWORD_STATE } from '@/config/constants';
+import { GlobalEntity } from '@/ecs/entities';
+import { IWeaponSystemHandler } from '../types.i';
+import { SwordWeaponSystemHandlerUpdateProp, ValidSwordWeaponEntity } from './types.p';
+
+class SwordWeaponSystemHandler implements IWeaponSystemHandler {
+  update({ entity, entities }: SwordWeaponSystemHandlerUpdateProp): void {
+    if (!this.isValidSword(entity)) return;
+
+    if (entity.state.current === SWORD_STATE.SLASHING) {
+      this.showAndPositionSword({ entity, entities });
+    } else {
+      this.hideSword({ entity });
+    }
+  }
+
+  private showAndPositionSword({
+    entity,
+    entities,
+  }: {
+    entity: ValidSwordWeaponEntity;
+    entities?: SwordWeaponSystemHandlerUpdateProp['entities'];
+  }): void {
+    const { sprite } = entity;
+
+    sprite.setVisible(true);
+    sprite.setDepth(DEPTH.ENTITIES + 1);
+
+    if (!entities) return;
+
+    const ownerId = entity.entityId.replace('sword_', '');
+    const owner = entities.get(ownerId);
+
+    if (owner?.sprite) {
+      this.updateTransform({ sword: entity, owner });
+    }
+  }
+
+  private updateTransform({
+    sword,
+    owner,
+  }: {
+    sword: ValidSwordWeaponEntity;
+    owner: GlobalEntity;
+  }): void {
+    if (!owner.sprite) return;
+
+    const isFlipped = owner.animation?.flipX ?? owner.sprite.flipX;
+    const { offsetX, offsetY, angle } = this.calculateOffsetAndAngle({
+      ownerState: owner.state?.current,
+      ownerInput: owner.input,
+      isFlipped,
+    });
+
+    sword.sprite.setPosition(owner.sprite.x + offsetX, owner.sprite.y + offsetY);
+    sword.sprite.setFlipX(isFlipped);
+    sword.sprite.setAngle(angle);
+
+    if (sword.animation) {
+      sword.animation.flipX = isFlipped;
+    }
+  }
+
+  private calculateOffsetAndAngle({
+    ownerState,
+    ownerInput,
+    isFlipped,
+  }: {
+    ownerState?: string;
+    ownerInput?: GlobalEntity['input'];
+    isFlipped: boolean;
+  }): { offsetX: number; offsetY: number; angle: number } {
+    const isUp = ownerState === CHARACTER_STATE.SHORT_ATTACK_UP || !!ownerInput?.up;
+    const isDown = ownerState === CHARACTER_STATE.SHORT_ATTACK_DOWN || !!ownerInput?.down;
+
+    if (isUp) {
+      return {
+        offsetX: 0,
+        offsetY: -SWORD.CONFIG.OFFSET,
+        angle: isFlipped ? 90 : -90,
+      };
+    }
+
+    if (isDown) {
+      return {
+        offsetX: 0,
+        offsetY: SWORD.CONFIG.OFFSET,
+        angle: isFlipped ? -90 : 90,
+      };
+    }
+
+    return {
+      offsetX: isFlipped ? -SWORD.CONFIG.OFFSET : SWORD.CONFIG.OFFSET,
+      offsetY: 0,
+      angle: 0,
+    };
+  }
+
+  private hideSword({ entity }: { entity: ValidSwordWeaponEntity }): void {
+    const { sprite } = entity;
+
+    sprite.setVisible(false);
+    sprite.setDepth(DEPTH.ENTITIES);
+    sprite.setAngle(0);
+    sprite.setPosition(-9999, -9999);
+  }
+
+  private isValidSword(entity: GlobalEntity): entity is ValidSwordWeaponEntity {
+    return !!entity.state && !!entity.sprite && entity.entityType === ENTITY_TYPES.SWORD;
+  }
+}
+
+export { SwordWeaponSystemHandler };

--- a/packages/client/src/game/ecs/systems/weapon/handlers/sword/index.ts
+++ b/packages/client/src/game/ecs/systems/weapon/handlers/sword/index.ts
@@ -1,0 +1,2 @@
+export * from './SwordWeaponSystemHandler';
+export * from './types.p';

--- a/packages/client/src/game/ecs/systems/weapon/handlers/sword/types.p.ts
+++ b/packages/client/src/game/ecs/systems/weapon/handlers/sword/types.p.ts
@@ -1,0 +1,15 @@
+import { StateComponent } from '@/ecs/components';
+import { GlobalEntity } from '@/ecs/entities';
+import { GlobalEntityMap } from '@/scenes/game';
+
+type SwordWeaponSystemHandlerUpdateProp = {
+  entity: GlobalEntity;
+  entities?: GlobalEntityMap;
+};
+
+type ValidSwordWeaponEntity = GlobalEntity & {
+  state: StateComponent;
+  sprite: Phaser.Physics.Matter.Sprite;
+};
+
+export type { SwordWeaponSystemHandlerUpdateProp, ValidSwordWeaponEntity };

--- a/packages/client/src/game/ecs/systems/weapon/handlers/types.i.ts
+++ b/packages/client/src/game/ecs/systems/weapon/handlers/types.i.ts
@@ -1,0 +1,8 @@
+import { GlobalEntity } from '@/ecs/entities';
+import { GlobalEntityMap } from '@/scenes/game';
+
+interface IWeaponSystemHandler {
+  update({ entity, entities }: { entity: GlobalEntity; entities?: GlobalEntityMap }): void;
+}
+
+export type { IWeaponSystemHandler };

--- a/packages/client/src/game/ecs/systems/weapon/index.ts
+++ b/packages/client/src/game/ecs/systems/weapon/index.ts
@@ -1,0 +1,2 @@
+export * from './WeaponSystem';
+export * from './types.p';

--- a/packages/client/src/game/ecs/systems/weapon/types.p.ts
+++ b/packages/client/src/game/ecs/systems/weapon/types.p.ts
@@ -1,0 +1,7 @@
+import { GlobalEntityMap } from '@/scenes/game';
+
+type WeaponSystemUpdateProp = {
+  entities: GlobalEntityMap;
+};
+
+export type { WeaponSystemUpdateProp };

--- a/packages/client/src/game/scenes/game/match/MatchScene.ts
+++ b/packages/client/src/game/scenes/game/match/MatchScene.ts
@@ -8,6 +8,7 @@ import {
   MovementSystem,
   VelocitySystem,
   StateSystem,
+  WeaponSystem,
 } from '@/ecs/systems';
 
 import { GlobalEntityMap } from './type.i';
@@ -25,6 +26,7 @@ export class MatchScene extends Phaser.Scene {
   private keymapSystem: KeymapSystem;
   private inputSystem: InputSystem;
   private stateSystem: StateSystem;
+  private weaponSystem: WeaponSystem;
   private movementSystem: MovementSystem;
   private velocitySystem: VelocitySystem;
   private animationSystem: AnimationSystem;
@@ -52,6 +54,7 @@ export class MatchScene extends Phaser.Scene {
     this.movementSystem = new MovementSystem();
     this.velocitySystem = new VelocitySystem({ scene: this });
     this.stateSystem = new StateSystem();
+    this.weaponSystem = new WeaponSystem();
     this.animationSystem = new AnimationSystem({ scene: this });
   }
 
@@ -104,6 +107,7 @@ export class MatchScene extends Phaser.Scene {
     this.movementSystem.update({ entities: this.entities });
     this.velocitySystem.update({ entities: this.entities });
     this.stateSystem.update({ entities: this.entities });
+    this.weaponSystem.update({ entities: this.entities });
     this.animationSystem.update({ entities: this.entities });
   }
 }


### PR DESCRIPTION
## Information

#### Describe What Was Done

- Created `weaponSystem` to manage weapon entities logic on every frame.
- Added `SwordWeaponSystemHandler` to position the sword always in front of the player when.
- Initially render sword outside the scene (x: 9999, y: 9999) to avoid loading it every time the player's attack.
- Position the sword in front of the player when attacking.

---

#### Detailed Summary (AI Generated)


<details>
	<summary>
🤖| Summary	</summary>
<br />

<!-- AI-SUMMARY-START -->


Implemented a decoupled ECS WeaponSystem and registered it in the MatchScene update cycle. This system orchestrates weapon visibility, depth, and positioning transforms. Specifically, it introduces the SwordWeaponSystemHandler to dynamically align the sword's position, rotation, and flip state based on the owner character's active state (supporting upward, downward, and standard forward attack slashes). Lastly, initialized the sword entity offscreen and hidden, delegating all spatial updates to the system.

<!-- AI-SUMMARY-END -->

</details>

---


#### Evidence

<details>
	<summary>
⏪️ | Before
	</summary>



https://github.com/user-attachments/assets/2c200ed8-c556-45ce-bd29-20481b72b08b






</details>
<details>
	<summary>
⏩ | After
	</summary>



https://github.com/user-attachments/assets/91af91f7-1f30-467f-9256-477d914a674f





</details>

---

#### Rollback Plan

Revert from the branch.


---

↗️ | **[Click to See The Preview](https://vulpy-labs.github.io/slash-out/preview/pr-88)**