### PR TITLE
091 | Combat - Part 14: Add player's collision handlers

### DIFF
--- a/docs/client/game/ecs/systems/collision/CollisionSystem.md
+++ b/docs/client/game/ecs/systems/collision/CollisionSystem.md
@@ -73,6 +73,7 @@ The `CollisionSystem` manages collision detection and handling for all game enti
 
 - Adds handler to internal Map
 - Associates with specified entityType
+- Can override default handlers for entity types
 
 **Side Effects:**
 
@@ -101,6 +102,8 @@ The `CollisionSystem` manages collision detection and handling for all game enti
   - `Phaser.Scene`: Required for Matter.js access
   - `MatterJS.BodyType`: Used for collision detection
   - `GlobalEntityMap`: Contains all game entities
+  - `ICollisionSystemHandler`: Interface that handlers must implement
+  - `ENTITY_TYPES`: Defines entity type constants
 - **Related Systems:**
   - `PlayerCollisionHandler`: Default handler for player collisions
 
@@ -110,3 +113,4 @@ The `CollisionSystem` manages collision detection and handling for all game enti
 
 > [!WARNING]  
 > **Performance:** Runs on every collision event. Keep handlers efficient.
+> **Implementation:** All handlers must implement ICollisionSystemHandler interface

--- a/docs/client/game/ecs/systems/collision/CollisionSystem.md
+++ b/docs/client/game/ecs/systems/collision/CollisionSystem.md
@@ -1,0 +1,112 @@
+# Collision System Documentation
+
+## Overview
+
+The `CollisionSystem` manages collision detection and handling for all game entities. It uses Matter.js collision events and delegates specific collision handling to registered handlers based on entity types.
+
+---
+
+## Technical Identity
+
+- **Type:** System
+- **Domain:** Physics/Collision
+
+---
+
+## Responsibilities
+
+- Registers Matter.js collision listeners
+- Delegates collision handling to type-specific handlers
+- Maintains mapping of entity types to collision handlers
+- Provides handler registration interface
+
+---
+
+## Data Schema
+
+### Manipulated Components
+
+- **Reads:** N/A
+- **Writes:** N/A
+
+### Configuration Props
+
+- `CollisionSystemCreateProp` (`*.p.ts`):
+  - `scene: Phaser.Scene`: Required for Matter.js event registration
+  - `entities: GlobalEntityMap`: Contains all game entities for collision resolution
+
+---
+
+## Lifecycle & Execution Flow
+
+1. **Initialization:**
+   - Constructs with default handler mappings
+   - Registers Matter.js collision listeners via `createMatterListeners()`
+
+2. **Main Operations:**
+   - Receives collision events from Matter.js
+   - Delegates collision handling to appropriate handlers
+   - Handles both sides of collision pairs
+
+3. **Teardown:** N/A
+
+---
+
+## Methods
+
+### `constructor()`
+
+**Description:** Initializes system with default handlers
+
+**Flow:**
+
+- Creates handlers Map
+- Registers `PlayerCollisionHandler` for `ENTITY_TYPES.PLAYER`
+
+---
+
+### `registerHandler({ entityType, handler })`
+
+**Description:** Allows registration of custom collision handlers
+
+**Flow:**
+
+- Adds handler to internal Map
+- Associates with specified entityType
+
+**Side Effects:**
+
+- Modifies internal handlers Map
+
+---
+
+### `createMatterListeners({ scene, entities })`
+
+**Description:** Registers Matter.js collision listeners
+
+**Flow:**
+
+- Attaches to Matter.js `collisionstart` event
+- Delegates collision pairs to appropriate handlers
+
+**Side Effects:**
+
+- Registers Matter.js event listener
+
+---
+
+## Dependencies & Relationships
+
+- **Core Dependencies:**
+  - `Phaser.Scene`: Required for Matter.js access
+  - `MatterJS.BodyType`: Used for collision detection
+  - `GlobalEntityMap`: Contains all game entities
+- **Related Systems:**
+  - `PlayerCollisionHandler`: Default handler for player collisions
+
+---
+
+## Maintenance Notes
+
+> [!WARNING]  
+> **Performance:** Runs on every collision event. Keep handlers efficient.

--- a/docs/client/game/ecs/systems/collision/handlers/player/PlayerCollisionHandler.md
+++ b/docs/client/game/ecs/systems/collision/handlers/player/PlayerCollisionHandler.md
@@ -1,0 +1,111 @@
+# Player Collision Handler Documentation
+
+## Overview
+
+The `PlayerCollisionHandler` implements collision handling logic specific to player entities. It detects collisions with active enemy weapons and triggers player death state.
+
+---
+
+## Technical Identity
+
+- **Type:** Handler
+- **Domain:** Combat/Collision
+
+---
+
+## Responsibilities
+
+- Detects valid player collisions
+- Identifies active enemy weapons
+- Updates player state on fatal collisions
+- Maintains collision validation logic
+
+---
+
+## Data Schema
+
+### Manipulated Components
+
+- **Reads:**
+  - `StateComponent`: Checks weapon and player states
+- **Writes:**
+  - `StateComponent`: Updates player state on death
+
+### Configuration Props
+
+- `CollisionHandleProp` (`*.p.ts`):
+  - `affected: GlobalEntity`: The entity being collided with
+  - `collider: GlobalEntity`: The entity causing the collision
+  - `entities: GlobalEntityMap`: Contains all game entities
+
+---
+
+## Lifecycle & Execution Flow
+
+1. **Initialization:** N/A
+2. **Main Operations:**
+   - Validates collision participants
+   - Checks weapon activation state
+   - Updates player state if fatal collision detected
+3. **Teardown:** N/A
+
+---
+
+## Methods
+
+### `handle({ affected, collider })`
+
+**Description:** Processes player collisions
+
+**Flow:**
+
+- Validates affected entity as player
+- Checks if collider is active enemy weapon
+- Updates player state to DEAD if fatal collision
+
+**Side Effects:**
+
+- Modifies player state component
+
+---
+
+### `private isActiveWeaponFromEnemy({ player, weapon })`
+
+**Description:** Validates if weapon is active and from enemy
+
+**Flow:**
+
+- Checks weapon ownership
+- Validates weapon activation state
+- Returns true if active enemy weapon
+
+---
+
+### `private isValidPlayer(entity)`
+
+**Description:** Type guard for valid player entities
+
+**Flow:**
+
+- Checks entity type
+- Validates required components
+- Returns true if valid player entity
+
+---
+
+## Dependencies & Relationships
+
+- **Core Dependencies:**
+  - `ENTITY_TYPES`: Defines entity type constants
+  - `CHARACTER_STATE`: Defines player state constants
+  - `SWORD_STATE`: Defines sword state constants
+  - `GUN_STATE`: Defines gun state constants
+- **Related Systems:**
+  - `CollisionSystem`: Delegates player collisions to this handler
+
+---
+
+## Maintenance Notes
+
+> [!WARNING]  
+> **Logic:** Must maintain strict validation of collision participants

--- a/docs/client/game/ecs/systems/collision/handlers/player/PlayerCollisionHandler.md
+++ b/docs/client/game/ecs/systems/collision/handlers/player/PlayerCollisionHandler.md
@@ -59,9 +59,10 @@ The `PlayerCollisionHandler` implements collision handling logic specific to pla
 
 **Flow:**
 
-- Validates affected entity as player
-- Checks if collider is active enemy weapon
+- Validates affected entity as player using `isValidPlayer()`
+- Checks if collider is active enemy weapon using `isActiveWeaponFromEnemy()`
 - Updates player state to DEAD if fatal collision
+- Sets death ticker duration using CHARACTER_COMBAT.DEATH.DURATION_TICKS
 
 **Side Effects:**
 
@@ -98,6 +99,7 @@ The `PlayerCollisionHandler` implements collision handling logic specific to pla
 - **Core Dependencies:**
   - `ENTITY_TYPES`: Defines entity type constants
   - `CHARACTER_STATE`: Defines player state constants
+  - `CHARACTER_COMBAT`: Defines combat-related constants
   - `SWORD_STATE`: Defines sword state constants
   - `GUN_STATE`: Defines gun state constants
 - **Related Systems:**

--- a/docs/client/game/managers/entity/EntityManager.md
+++ b/docs/client/game/managers/entity/EntityManager.md
@@ -48,7 +48,7 @@ The `EntityManager` is the single source of truth for all game entities, enforci
    - Constructs with scene and `matchConfig` references
    - Initializes `PlayerBuilder` and `WeaponBuilder` with creation callbacks
    - Loads player and weapon assets via builder load methods
-   - Automatically creates sword weapons for each player
+   - Automatically creates sword and gun weapons for each player
 
 2. **Main Operations:**
    - Creates player entities from `matchConfig` via `PlayerBuilder.build()`
@@ -78,14 +78,16 @@ The `EntityManager` is the single source of truth for all game entities, enforci
 
 ---
 
-### `createPlayers()`
+### `createPlayers(spawnPoints?: { x: number; y: number }[])`
 
 **Description:** Instantiates player entities from match configuration
 
 **Flow:**
 
 - Iterates `matchConfig.players.characters`
+- Uses optional spawnPoints array for positioning
 - Delegates to `PlayerBuilder.build()` for each character
+- Creates sword and gun weapons for each player via `WeaponBuilder`
 - Uses `registerEntity()` callback for player registration
 
 **Side Effects:**
@@ -212,9 +214,10 @@ The `EntityManager` is the single source of truth for all game entities, enforci
 - **Core Dependencies:**
   - `Phaser.Scene`: Required for sprite management
   - `PlayerBuilder`: Handles player entity construction
+  - `WeaponBuilder`: Handles weapon entity construction
   - `MatchConfig`: Provides player character definitions
 - **Related Systems:**
-  - `PlayerBuilder`: For player entity creation
+  - `PlayerBuilder`: For player entity creation  
   - `WeaponBuilder`: For weapon entity creation
 
 ---
@@ -226,3 +229,4 @@ The `EntityManager` is the single source of truth for all game entities, enforci
 >
 > - Destroy Phaser sprites
 > - Remove from both players and entities Maps
+> - Clean up any child entities owned by the destroyed entity

--- a/packages/client/src/game/config/constants/character/combat/characterCombat.ts
+++ b/packages/client/src/game/config/constants/character/combat/characterCombat.ts
@@ -3,7 +3,7 @@ const CHARACTER_COMBAT = {
     DURATION_TICKS: 45,
   },
   DEATH: {
-    DURATION_TICKS: 60,
+    DURATION_TICKS: 65,
   },
 } as const;
 

--- a/packages/client/src/game/config/constants/character/combat/characterCombat.ts
+++ b/packages/client/src/game/config/constants/character/combat/characterCombat.ts
@@ -2,6 +2,9 @@ const CHARACTER_COMBAT = {
   ATTACK: {
     DURATION_TICKS: 45,
   },
+  DEATH: {
+    DURATION_TICKS: 60,
+  },
 } as const;
 
 export { CHARACTER_COMBAT };

--- a/packages/client/src/game/ecs/systems/collision/CollisionSystem.ts
+++ b/packages/client/src/game/ecs/systems/collision/CollisionSystem.ts
@@ -1,12 +1,15 @@
-import { EntityTypes } from '@/config/constants';
+import { ENTITY_TYPES, EntityTypes } from '@/config/constants';
 import { ICollisionSystemHandler } from './handlers';
 import { CollisionSystemCreateProp } from './types.p';
+import { PlayerCollisionHandler } from './handlers';
 
 class CollisionSystem {
   private readonly handlers: Map<EntityTypes, ICollisionSystemHandler>;
 
   constructor() {
-    this.handlers = new Map<EntityTypes, ICollisionSystemHandler>();
+    this.handlers = new Map<EntityTypes, ICollisionSystemHandler>([
+      [ENTITY_TYPES.PLAYER, new PlayerCollisionHandler()],
+    ]);
   }
 
   registerHandler({

--- a/packages/client/src/game/ecs/systems/collision/handlers/index.ts
+++ b/packages/client/src/game/ecs/systems/collision/handlers/index.ts
@@ -1,1 +1,2 @@
 export * from './types.i';
+export * from './player/PlayerCollisionHandler';

--- a/packages/client/src/game/ecs/systems/collision/handlers/player/PlayerCollisionHandler.ts
+++ b/packages/client/src/game/ecs/systems/collision/handlers/player/PlayerCollisionHandler.ts
@@ -7,12 +7,12 @@ import {
 } from '@/config/constants';
 import { GlobalEntity } from '@/ecs/entities';
 import { CollisionHandleProp, ICollisionSystemHandler } from '../types.i';
-import { ValidPlayerCollisionEntity } from './types.p';
 
 class PlayerCollisionHandler implements ICollisionSystemHandler {
   handle({ affected, collider }: CollisionHandleProp): void {
-    if (!this.isValidPlayer(affected)) return;
+    if (!this.isValidPlayer({ entity: affected })) return;
     if (!this.isActiveWeaponFromEnemy({ player: affected, weapon: collider })) return;
+    if (!affected.state) return;
 
     affected.state.current = CHARACTER_STATE.DEAD;
     affected.state.ticker = CHARACTER_COMBAT.DEATH.DURATION_TICKS;
@@ -22,7 +22,7 @@ class PlayerCollisionHandler implements ICollisionSystemHandler {
     player,
     weapon,
   }: {
-    player: ValidPlayerCollisionEntity;
+    player: GlobalEntity;
     weapon: GlobalEntity;
   }): boolean {
     const isEnemyWeapon = weapon.ownerEntityId !== player.entityId;
@@ -36,7 +36,7 @@ class PlayerCollisionHandler implements ICollisionSystemHandler {
     return (isEnemyWeapon && isActiveSword) || isActiveBullet;
   }
 
-  private isValidPlayer(entity: GlobalEntity): entity is ValidPlayerCollisionEntity {
+  private isValidPlayer({ entity }: { entity: GlobalEntity }): boolean {
     return (
       entity.entityType === ENTITY_TYPES.PLAYER &&
       !!entity.state &&

--- a/packages/client/src/game/ecs/systems/collision/handlers/player/PlayerCollisionHandler.ts
+++ b/packages/client/src/game/ecs/systems/collision/handlers/player/PlayerCollisionHandler.ts
@@ -12,7 +12,7 @@ class PlayerCollisionHandler implements ICollisionSystemHandler {
   handle({ affected, collider }: CollisionHandleProp): void {
     if (!this.isValidPlayer({ entity: affected })) return;
     if (!this.isActiveWeaponFromEnemy({ player: affected, weapon: collider })) return;
-    if (!affected.state) return;
+    if (!affected.state || affected.state.current === CHARACTER_STATE.DEAD) return;
 
     affected.state.current = CHARACTER_STATE.DEAD;
     affected.state.ticker = CHARACTER_COMBAT.DEATH.DURATION_TICKS;

--- a/packages/client/src/game/ecs/systems/collision/handlers/player/PlayerCollisionHandler.ts
+++ b/packages/client/src/game/ecs/systems/collision/handlers/player/PlayerCollisionHandler.ts
@@ -1,0 +1,49 @@
+import {
+  CHARACTER_COMBAT,
+  CHARACTER_STATE,
+  ENTITY_TYPES,
+  GUN_STATE,
+  SWORD_STATE,
+} from '@/config/constants';
+import { GlobalEntity } from '@/ecs/entities';
+import { CollisionHandleProp, ICollisionSystemHandler } from '../types.i';
+import { ValidPlayerCollisionEntity } from './types.p';
+
+class PlayerCollisionHandler implements ICollisionSystemHandler {
+  handle({ affected, collider }: CollisionHandleProp): void {
+    if (!this.isValidPlayer(affected)) return;
+    if (!this.isActiveWeaponFromEnemy({ player: affected, weapon: collider })) return;
+
+    affected.state.current = CHARACTER_STATE.DEAD;
+    affected.state.ticker = CHARACTER_COMBAT.DEATH.DURATION_TICKS;
+  }
+
+  private isActiveWeaponFromEnemy({
+    player,
+    weapon,
+  }: {
+    player: ValidPlayerCollisionEntity;
+    weapon: GlobalEntity;
+  }): boolean {
+    const isEnemyWeapon = weapon.ownerEntityId !== player.entityId;
+
+    const isActiveSword =
+      weapon.entityType === ENTITY_TYPES.SWORD && weapon.state?.current === SWORD_STATE.SLASHING;
+
+    const isActiveBullet =
+      weapon.entityType === ENTITY_TYPES.GUN && weapon.state?.current === GUN_STATE.IN_FLIGHT;
+
+    return (isEnemyWeapon && isActiveSword) || isActiveBullet;
+  }
+
+  private isValidPlayer(entity: GlobalEntity): entity is ValidPlayerCollisionEntity {
+    return (
+      entity.entityType === ENTITY_TYPES.PLAYER &&
+      !!entity.state &&
+      !!entity.sprite &&
+      !!entity.movement
+    );
+  }
+}
+
+export { PlayerCollisionHandler };

--- a/packages/client/src/game/ecs/systems/collision/handlers/player/index.ts
+++ b/packages/client/src/game/ecs/systems/collision/handlers/player/index.ts
@@ -1,0 +1,1 @@
+export * from './PlayerCollisionHandler';

--- a/packages/client/src/game/ecs/systems/collision/handlers/player/types.p.ts
+++ b/packages/client/src/game/ecs/systems/collision/handlers/player/types.p.ts
@@ -1,0 +1,15 @@
+import { MovementComponent, StateComponent } from '@/ecs/components';
+import { GlobalEntity } from '@/ecs/entities';
+
+type PlayerCollisionHandleProp = {
+  affected: GlobalEntity;
+  collider: GlobalEntity;
+};
+
+type ValidPlayerCollisionEntity = GlobalEntity & {
+  state: StateComponent;
+  sprite: Phaser.Physics.Matter.Sprite;
+  movement: MovementComponent;
+};
+
+export type { PlayerCollisionHandleProp, ValidPlayerCollisionEntity };

--- a/packages/client/src/game/ecs/systems/movement/MovementSystem.ts
+++ b/packages/client/src/game/ecs/systems/movement/MovementSystem.ts
@@ -1,9 +1,10 @@
+import { CHARACTER_STATE } from '@/config/constants';
 import { MovementSystemUpdateProp } from './types.p';
 
 class MovementSystem {
   update({ entities }: MovementSystemUpdateProp) {
-    entities.forEach(({ input, movement }) => {
-      if (!input || !movement) return;
+    entities.forEach(({ input, movement, state }) => {
+      if (!input || !movement || state?.current === CHARACTER_STATE.DEAD) return;
 
       movement.intent.moveX = 0;
       movement.intent.moveY = 0;

--- a/packages/client/src/game/ecs/systems/state/handlers/sword/types.p.ts
+++ b/packages/client/src/game/ecs/systems/state/handlers/sword/types.p.ts
@@ -1,8 +1,10 @@
 import { InputComponent, StateComponent } from '@/ecs/components';
 import { GlobalEntity } from '@/ecs/entities';
+import { GlobalEntityMap } from '@/scenes/game';
 
 type SwordStateHandlerUpdateProp = {
   entity: GlobalEntity;
+  entities?: GlobalEntityMap;
 };
 
 type ValidSwordEntity = GlobalEntity & {

--- a/packages/client/src/game/managers/entity/EntityManager.ts
+++ b/packages/client/src/game/managers/entity/EntityManager.ts
@@ -134,6 +134,10 @@ class EntityManager {
       this.players.set(entity.entityId, entity);
     }
 
+    if (entity.sprite?.body) {
+      (entity.sprite.body as MatterJS.BodyType).label = entity.entityId;
+    }
+
     this.entities.set(entity.entityId, entity);
   }
 }


### PR DESCRIPTION
## Information

#### Describe What Was Done

- Create collision handler for players

---

#### Detailed Summary (AI Generated)


<details>
	<summary>
🤖| Summary	</summary>
<br />

<!-- AI-SUMMARY-START -->
This pull request introduces player collision handling and character death mechanics triggered by incoming enemy weapon attacks. It also integrates death state checks into movement handling, assigns physics body labels during entity registration, and updates the relevant documentation.

**Collision Handling & Combat Logic**
- Added `PlayerCollisionHandler` to detect collisions between player entities and active enemy weapons (slashing swords or in-flight bullets), transitioning affected players into the `DEAD` state.
- Registered `PlayerCollisionHandler` by default for player entities within `CollisionSystem`.
- Defined a `DEATH.DURATION_TICKS` constant (65 ticks) in combat configurations to set the duration of the player death sequence.

**Entity & Movement Systems**
- Updated `MovementSystem` to bypass movement and input processing for entities in the `DEAD` state.
- Updated `EntityManager` to assign the entity's `entityId` as the label on its physics body during registration.
- Added an optional `entities` map property to `SwordStateHandlerUpdateProp`.

**Documentation**
- Added new architecture and lifecycle documentation for `PlayerCollisionHandler`.
- Updated `CollisionSystem.md` and `EntityManager.md` to reflect default handler registration, physics body labeling, and entity creation flows.
<!-- AI-SUMMARY-END -->

</details>


---


#### Evidence

<details>
	<summary>
⏪️ | Before - Players ignoring weapons
	</summary>



https://github.com/user-attachments/assets/48c54a74-3200-4f3d-a598-c6e6655570d1






</details>
<details>
	<summary>
⏩ | After - Players reacting to weapons
	</summary>




https://github.com/user-attachments/assets/d59f0294-4f9b-45cb-afe1-ec8d79047fc3




</details>

---

#### Rollback Plan

Revert from the branch.


---

↗️ | **[Click to See The Preview](https://vulpy-labs.github.io/slash-out/preview/pr-99)**